### PR TITLE
chore: split lint/test from PR creation

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,17 +1,10 @@
 name: Lint and Test
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
-
-  test:
-    uses: ./.github/workflows/test.yml
-
   create-release-pr:
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - test
-      - lint
     uses: ./.github/workflows/create_release_pr.yml

--- a/.github/workflows/on_push_go_changes.yml
+++ b/.github/workflows/on_push_go_changes.yml
@@ -1,0 +1,14 @@
+name: Lint and Test
+
+on:
+  push:
+    paths:
+      - '**.go'
+      - 'backend/**'
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    uses: ./.github/workflows/test.yml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for automated linting and testing of Go files on push events.
  
- **Changes**
	- Modified existing workflow to trigger only on pushes to the `main` branch, removing `lint` and `test` jobs. The `create-release-pr` job now runs independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->