### PR TITLE
Fix: Show last backup only for current backup profile

### DIFF
--- a/frontend/src/components/BackupProfileCard.vue
+++ b/frontend/src/components/BackupProfileCard.vue
@@ -133,7 +133,8 @@ onUnmounted(() => {
             </span>
             <span v-else-if='lastArchive' class='tooltip' :data-tip='toLongDateString(lastArchive.createdAt)'>
               <span :class='toCreationTimeBadge(lastArchive?.createdAt)'>{{ toRelativeTimeString(lastArchive.createdAt) }}</span>
-          </span>
+            </span>
+            <span v-else>-</span>
           </div>
         </div>
         <div class='divider'></div>

--- a/frontend/src/components/RepoCard.vue
+++ b/frontend/src/components/RepoCard.vue
@@ -82,7 +82,9 @@ async function getRepo() {
     sizeOnDisk.value = toHumanReadableSize(repo.value.statsUniqueCsize);
     failedBackupRun.value = await backupClient.GetLastBackupErrorMsg(backupId);
 
-    lastArchive.value = await repoClient.GetLastArchiveByBackupId(backupId) ?? undefined;
+    const archive = await repoClient.GetLastArchiveByBackupId(backupId) ?? undefined;
+    // Only set lastArchive if it has a valid ID (id > 0)
+    lastArchive.value = archive && archive.id > 0 ? archive : undefined;
   } catch (error: any) {
     await showAndLogError("Failed to get repository", error);
   }
@@ -179,6 +181,7 @@ onUnmounted(() => {
         <span v-else-if='lastArchive' class='tooltip' :data-tip='toLongDateString(lastArchive.createdAt)'>
           <span :class='toCreationTimeBadge(lastArchive?.createdAt)'>{{ toRelativeTimeString(lastArchive.createdAt) }}</span>
         </span>
+        <span v-else>-</span>
       </p>
       <p>{{ $t("total_size") }}: {{ totalSize }}</p>
       <p>{{ $t("size_on_disk") }}: {{ sizeOnDisk }}</p>

--- a/frontend/src/pages/RepositoryPage.vue
+++ b/frontend/src/pages/RepositoryPage.vue
@@ -93,7 +93,9 @@ async function getRepoState() {
     sizeOnDisk.value = toHumanReadableSize(repo.value.statsUniqueCsize);
     failedBackupRun.value = await repoClient.GetLastBackupErrorMsg(repoId);
 
-    lastArchive.value = await repoClient.GetLastArchiveByRepoId(repoId) ?? undefined;
+    const archive = await repoClient.GetLastArchiveByRepoId(repoId) ?? undefined;
+    // Only set lastArchive if it has a valid ID (id > 0)
+    lastArchive.value = archive && archive.id > 0 ? archive : undefined;
   } catch (error: any) {
     await showAndLogError("Failed to get repository state", error);
   }
@@ -213,6 +215,7 @@ onUnmounted(() => {
         <span v-else-if='lastArchive' class='tooltip' :data-tip='toLongDateString(lastArchive.createdAt)'>
           <span :class='toCreationTimeBadge(lastArchive?.createdAt)'>{{ toRelativeTimeString(lastArchive.createdAt) }}</span>
         </span>
+        <span v-else>-</span>
       </div>
       <div class='divider'></div>
       <div class='flex justify-between'>


### PR DESCRIPTION
## Summary
- Fixes bug where repository card showed "last backup" from other backup profiles
- Only displays last backup information when it belongs to the current backup profile
- Shows a hyphen (-) when no relevant backup exists

## Test plan
- Connect a repository to multiple backup profiles
- Create backups with different profiles
- Verify that each backup profile page shows only backups relevant to that profile

Closes TECH-90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced archive display: When archive data is not available, a hyphen ("-") now clearly indicates its absence.
	- Improved logic for determining the validity of archives, ensuring only valid entries are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->