### PR TITLE
fix: enable macOS universal build support in task system

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,12 +20,12 @@ tasks:
   build:
     desc: Builds the application
     cmds:
-      - task: "{{OS}}:build"
+      - task: '{{if eq .PLATFORM "darwin/universal"}}darwin:build:universal{{else}}{{OS}}:build{{end}}'
 
   package:
     desc: Packages a production build of the application
     cmds:
-      - task: "{{OS}}:package"
+      - task: '{{if eq .PLATFORM "darwin/universal"}}darwin:package:universal{{else}}{{OS}}:package{{end}}'
 
   run:
     desc: Runs the application


### PR DESCRIPTION
Update build and package tasks to check PLATFORM environment variable and route to darwin:build:universal when PLATFORM=darwin/universal. This fixes GitHub Actions workflow not building universal binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and package tasks to better handle platform-specific configurations, including enhanced support for universal builds on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->