### PR TITLE
chore: update build configuration and branding

### DIFF
--- a/build/config.yml
+++ b/build/config.yml
@@ -1,16 +1,16 @@
 # This file contains the configuration for this project.
-# When you update `info` or `fileAssociations`, run `wails3 task common:update:build-assets` to update the assets.
+# When you update `info` or `fileAssociations`, run `task common:update:build-assets` to update the assets.
 # Note that this will overwrite any changes you have made to the assets.
 version: '3'
 
 # This information is used to generate the build assets.
 info:
-  companyName: "Raphael Thurnherr" # The name of the company
+  companyName: "Loomi Labs" # The name of the company
   productName: "Arco" # The name of the application
   productIdentifier: "com.backup.arco" # The unique product identifier
-  description: "A modern, user-friendly Borg backup client" # The application description
-  copyright: "(c) 2024, Raphael Thurnherr" # Copyright text
-  comments: "Desktop client for BorgBackup" # Comments
+  description: "A modern, user-friendly backup application based on BorgBackup" # The application description
+  copyright: "(c) 2025, Loomi Labs" # Copyright text
+  comments: "Backup application based on BorgBackup" # Comments
   homepage: "https://arco-backup.com" # The homepage of the application
 
 # Dev mode configuration
@@ -32,15 +32,15 @@ dev_mode:
       - "*.go"
     git_ignore: true
   executes:
-    - cmd: wails3 task common:install:frontend:deps
+    - cmd: task common:install:frontend:deps
       type: once
-    - cmd: wails3 task common:dev:frontend
+    - cmd: task common:dev:frontend
       type: background
     - cmd: go mod tidy
       type: blocking
-    - cmd: wails3 task build
+    - cmd: task build
       type: blocking
-    - cmd: wails3 task run
+    - cmd: task run
       type: primary
 
 # File Associations

--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -2,27 +2,27 @@
 <plist version="1.0">
     <dict>
         <key>CFBundlePackageType</key>
-        <string>APPL</string>
+            <string>APPL</string>
         <key>CFBundleName</key>
-        <string>Arco</string>
+            <string>Arco</string>
         <key>CFBundleExecutable</key>
-        <string>arco</string>
+            <string>arco</string>
         <key>CFBundleIdentifier</key>
-        <string>com.backup.arco</string>
+            <string>com.backup.arco</string>
         <key>CFBundleVersion</key>
-        <string></string>
+            <string>0.14.1</string>
         <key>CFBundleGetInfoString</key>
-        <string>Desktop client for BorgBackup</string>
+            <string>Backup application based on BorgBackup</string>
         <key>CFBundleShortVersionString</key>
-        <string></string>
+            <string>0.14.1</string>
         <key>CFBundleIconFile</key>
-        <string>icons</string>
+            <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+            <string>10.15.0</string>
         <key>NSHighResolutionCapable</key>
-        <string>true</string>
+            <string>true</string>
         <key>NSHumanReadableCopyright</key>
-        <string>(c) 2024, Raphael Thurnherr</string>
+            <string>(c) 2025, Loomi Labs</string>
         <key>NSAppTransportSecurity</key>
         <dict>
             <key>NSAllowsLocalNetworking</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -2,26 +2,26 @@
 <plist version="1.0">
     <dict>
         <key>CFBundlePackageType</key>
-        <string>APPL</string>
+            <string>APPL</string>
         <key>CFBundleName</key>
-        <string>Arco</string>
+            <string>Arco</string>
         <key>CFBundleExecutable</key>
-        <string>arco</string>
+            <string>arco</string>
         <key>CFBundleIdentifier</key>
-        <string>com.backup.arco</string>
+            <string>com.backup.arco</string>
         <key>CFBundleVersion</key>
-        <string></string>
+            <string>0.14.1</string>
         <key>CFBundleGetInfoString</key>
-        <string>Desktop client for BorgBackup</string>
+            <string>Backup application based on BorgBackup</string>
         <key>CFBundleShortVersionString</key>
-        <string></string>
+            <string>0.14.1</string>
         <key>CFBundleIconFile</key>
-        <string>icons</string>
+            <string>icons</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+            <string>10.15.0</string>
         <key>NSHighResolutionCapable</key>
-        <string>true</string>
+            <string>true</string>
         <key>NSHumanReadableCopyright</key>
-        <string>(c) 2024, Raphael Thurnherr</string>
+            <string>(c) 2025, Loomi Labs</string>
     </dict>
 </plist>

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -6,12 +6,12 @@
 name: "arco"
 arch: ${GOARCH}
 platform: "linux"
-version: ""
+version: "0.14.1"
 section: "default"
 priority: "extra"
 maintainer: ${GIT_COMMITTER_NAME} <${GIT_COMMITTER_EMAIL}>
-description: "A modern, user-friendly Borg backup client"
-vendor: "Raphael Thurnherr"
+description: "A modern, user-friendly backup application based on BorgBackup"
+vendor: "Loomi Labs"
 homepage: "https://wails.io"
 license: "MIT"
 release: "1"
@@ -19,15 +19,36 @@ release: "1"
 contents:
   - src: "./bin/arco"
     dst: "/usr/local/bin/arco"
-  - src: "./build/appicon-light.png"
+  - src: "./build/appicon.png"
     dst: "/usr/share/icons/hicolor/128x128/apps/arco.png"
   - src: "./build/linux/arco.desktop"
     dst: "/usr/share/applications/arco.desktop"
 
+# Default dependencies for Debian 12/Ubuntu 22.04+ with WebKit 4.1
 depends:
-  - gtk3
-#  - libwebkit2gtk
-  - webkit2gtk-4.1
+  - libgtk-3-0
+  - libwebkit2gtk-4.1-0
+
+# Distribution-specific overrides for different package formats and WebKit versions
+overrides:
+  # RPM packages for RHEL/CentOS/AlmaLinux/Rocky Linux (WebKit 4.0)
+  rpm:
+    depends:
+      - gtk3
+      - webkit2gtk4.1
+  
+  # Arch Linux packages (WebKit 4.1)  
+  archlinux:
+    depends:
+      - gtk3
+      - webkit2gtk-4.1
+
+# scripts section to ensure desktop database is updated after install
+scripts:
+  postinstall: "./build/linux/nfpm/scripts/postinstall.sh"
+  # You can also add preremove, postremove if needed
+  # preremove: "./build/linux/nfpm/scripts/preremove.sh"
+  # postremove: "./build/linux/nfpm/scripts/postremove.sh"
 
 # replaces:
 #   - foobar
@@ -44,8 +65,3 @@ depends:
 #   - not-foo
 #   - not-bar
 # changelog: "changelog.yaml"
-# scripts:
-#   preinstall: ./build/linux/nfpm/scripts/preinstall.sh
-#   postinstall: ./build/linux/nfpm/scripts/postinstall.sh
-#   preremove: ./build/linux/nfpm/scripts/preremove.sh
-#   postremove: ./build/linux/nfpm/scripts/postremove.sh

--- a/build/windows/info.json
+++ b/build/windows/info.json
@@ -1,15 +1,15 @@
 {
 	"fixed": {
-		"file_version": ""
+		"file_version": "0.14.1"
 	},
 	"info": {
 		"0000": {
-			"ProductVersion": "",
-			"CompanyName": "Raphael Thurnherr",
-			"FileDescription": "A modern, user-friendly Borg backup client",
-			"LegalCopyright": "(c) 2024, Raphael Thurnherr",
+			"ProductVersion": "0.14.1",
+			"CompanyName": "Loomi Labs",
+			"FileDescription": "A modern, user-friendly backup application based on BorgBackup",
+			"LegalCopyright": "(c) 2025, Loomi Labs",
 			"ProductName": "Arco",
-			"Comments": "Desktop client for BorgBackup"
+			"Comments": "Backup application based on BorgBackup"
 		}
 	}
 }

--- a/build/windows/nsis/wails_tools.nsh
+++ b/build/windows/nsis/wails_tools.nsh
@@ -8,16 +8,16 @@
     !define INFO_PROJECTNAME "arco"
 !endif
 !ifndef INFO_COMPANYNAME
-    !define INFO_COMPANYNAME "Raphael Thurnherr"
+    !define INFO_COMPANYNAME "Loomi Labs"
 !endif
 !ifndef INFO_PRODUCTNAME
     !define INFO_PRODUCTNAME "Arco"
 !endif
 !ifndef INFO_PRODUCTVERSION
-    !define INFO_PRODUCTVERSION ""
+    !define INFO_PRODUCTVERSION "0.14.1"
 !endif
 !ifndef INFO_COPYRIGHT
-    !define INFO_COPYRIGHT "(c) 2024, Raphael Thurnherr"
+    !define INFO_COPYRIGHT "(c) 2025, Loomi Labs"
 !endif
 !ifndef PRODUCT_EXECUTABLE
     !define PRODUCT_EXECUTABLE "${INFO_PROJECTNAME}.exe"
@@ -158,7 +158,7 @@ RequestExecutionLevel "${REQUEST_EXECUTION_LEVEL}"
 
     ${If} ${REQUEST_EXECUTION_LEVEL} == "user"
         # If the installer is run in user level, check the user specific key exists and is not empty then webview2 is already installed
-	    ReadRegStr $0 HKCU "Software\Microsoft\EdgeUpdate\Clients{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" "pv"
+	    ReadRegStr $0 HKCU "Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" "pv"
         ${If} $0 != ""
             Goto ok
         ${EndIf}

--- a/build/windows/wails.exe.manifest
+++ b/build/windows/wails.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="com.backup.arco" version="" processorArchitecture="*"/>
+    <assemblyIdentity type="win32" name="com.backup.arco" version="0.14.1" processorArchitecture="*"/>
     <dependency>
         <dependentAssembly>
             <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
@@ -12,4 +12,11 @@
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness> <!-- falls back to per-monitor if per-monitor v2 is not supported -->
         </asmv3:windowsSettings>
     </asmv3:application>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
 </assembly>


### PR DESCRIPTION
- Update company/vendor
- Update copyright year to 2025
- Set application version to 0.14.1 across all build files
- Update product description to "Backup application based on BorgBackup"
- Remove "wails3" prefix from task commands in config.yml
- Enhance Linux packaging with improved dependencies and scripts
- Add Windows trust info and fix registry key formatting
- Update minimum macOS version to 10.15.0