### PR TITLE
fix(repository): ensure cancellation awaits process termination

### DIFF
--- a/frontend/bindings/github.com/loomi-labs/arco/backend/app/statemachine/models.ts
+++ b/frontend/bindings/github.com/loomi-labs/arco/backend/app/statemachine/models.ts
@@ -7,10 +7,10 @@ import { Create as $Create } from "@wailsio/runtime";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import * as types$1 from "../types/models.js";
+import * as types$0 from "../types/models.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import * as types$0 from "../../borg/types/models.js";
+import * as types$1 from "../../borg/types/models.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
 import * as ent$0 from "../../ent/models.js";
@@ -115,13 +115,13 @@ export class BackingUp {
 }
 
 export class Backup {
-    "backupId": types$1.BackupId;
-    "progress"?: types$0.BackupProgress | null;
+    "backupId": types$0.BackupId;
+    "progress"?: types$1.BackupProgress | null;
 
     /** Creates a new Backup instance. */
     constructor($$source: Partial<Backup> = {}) {
         if (!("backupId" in $$source)) {
-            this["backupId"] = (new types$1.BackupId());
+            this["backupId"] = (new types$0.BackupId());
         }
 
         Object.assign(this, $$source);
@@ -254,14 +254,14 @@ export enum ErrorType {
 };
 
 export class ExaminePrune {
-    "backupId": types$1.BackupId;
+    "backupId": types$0.BackupId;
     "pruningRule": ent$0.PruningRule | null;
     "saveResults": boolean;
 
     /** Creates a new ExaminePrune instance. */
     constructor($$source: Partial<ExaminePrune> = {}) {
         if (!("backupId" in $$source)) {
-            this["backupId"] = (new types$1.BackupId());
+            this["backupId"] = (new types$0.BackupId());
         }
         if (!("pruningRule" in $$source)) {
             this["pruningRule"] = null;
@@ -558,12 +558,12 @@ export class OperationUnion {
 }
 
 export class Prune {
-    "backupId": types$1.BackupId;
+    "backupId": types$0.BackupId;
 
     /** Creates a new Prune instance. */
     constructor($$source: Partial<Prune> = {}) {
         if (!("backupId" in $$source)) {
-            this["backupId"] = (new types$1.BackupId());
+            this["backupId"] = (new types$0.BackupId());
         }
 
         Object.assign(this, $$source);
@@ -583,12 +583,12 @@ export class Prune {
 }
 
 export class Pruning {
-    "backupId": types$1.BackupId;
+    "backupId": types$0.BackupId;
 
     /** Creates a new Pruning instance. */
     constructor($$source: Partial<Pruning> = {}) {
         if (!("backupId" in $$source)) {
-            this["backupId"] = (new types$1.BackupId());
+            this["backupId"] = (new types$0.BackupId());
         }
 
         Object.assign(this, $$source);
@@ -805,8 +805,8 @@ export class UnmountArchive {
 
 // Private type creation functions
 const $$createType0 = Backup.createFrom;
-const $$createType1 = types$1.BackupId.createFrom;
-const $$createType2 = types$0.BackupProgress.createFrom;
+const $$createType1 = types$0.BackupId.createFrom;
+const $$createType2 = types$1.BackupProgress.createFrom;
 const $$createType3 = $Create.Nullable($$createType2);
 const $$createType4 = ent$0.PruningRule.createFrom;
 const $$createType5 = $Create.Nullable($$createType4);


### PR DESCRIPTION
## Summary

Fixes TECH-141 by ensuring backup operation cancellation properly waits for borg process termination before cleanup.

- **Core fix**: Added cancellation handling in operation goroutine that waits for borg process to terminate via blocking `Execute()` call before running cleanup logic
- **Simplified cancellation flow**: `CancelOperation` now just triggers context cancellation and returns, letting the goroutine handle all cleanup asynchronously
- **Eliminated code duplication**: Refactored to use `CompleteOperation` and `RemoveOperation` for cleanup instead of manual state transitions and tracking
- **Fixed state transition bug**: Prevented invalid "Queued → Queued" transitions when operations complete while others are queued

## Technical Details

### Before
When cancelling an operation, the code would:
1. Trigger context cancellation
2. Immediately remove from active tracking
3. Manually transition states
4. Start next operation

This caused a race condition where the next operation could start before the borg process fully terminated.

### After
When cancelling an operation:
1. Trigger context cancellation and return
2. Operation goroutine waits for borg process to terminate (blocking on `Execute()`)
3. Goroutine detects cancellation via `status.HasBeenCanceled`
4. Goroutine calls `CompleteOperation` which handles all cleanup, state transitions, and starting next operations

This ensures proper synchronization and eliminates ~100 lines of duplicate cleanup code.

## Testing

To verify the fix:
1. Start a backup operation on a repository
2. Queue another heavy operation while first is running
3. Cancel the first operation
4. Verify: no "invalid state transition" errors in logs, second operation starts properly

Closes TECH-141