### PR TITLE
fix(build): correct version injection in CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,42 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # Validate version for release builds
+      - name: Validate version for release
+        if: inputs.push_artifacts == true
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          # Check if version is empty
+          if [ -z "$VERSION" ]; then
+            echo "::error::VERSION is required for release builds but was not provided"
+            echo "inputs.version: '${{ inputs.version }}'"
+            exit 1
+          fi
+
+          # Check if version is 'dev'
+          if [ "$VERSION" = "dev" ]; then
+            echo "::error::VERSION cannot be 'dev' for release builds"
+            echo "inputs.version: '$VERSION'"
+            exit 1
+          fi
+
+          # Check if version is v0.0.0
+          if [ "$VERSION" = "v0.0.0" ]; then
+            echo "::error::VERSION cannot be 'v0.0.0' for release builds"
+            echo "inputs.version: '$VERSION'"
+            exit 1
+          fi
+
+          # Validate version format (should start with 'v' and contain digits)
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::VERSION must be in format 'vX.Y.Z' (e.g., v1.2.3)"
+            echo "inputs.version: '$VERSION'"
+            exit 1
+          fi
+
+          echo "✅ Version validation passed: $VERSION"
+
       - name: Check for relevant changes
         uses: dorny/paths-filter@v3
         id: changes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,7 +14,7 @@ vars:
   BIN_DIR: "bin"
   VITE_PORT: '{{.WAILS_VITE_PORT | default 9245}}'
   VERSION:
-    sh: sed -n 's/.*"\."\s*:\s*"\([0-9.]*\)".*/\1/p' .release-please-manifest.json
+    sh: echo "${VERSION:-$(sed -n 's/.*"\."\s*:\s*"\([0-9.]*\)".*/\1/p' .release-please-manifest.json)}"
 
 tasks:
   build:

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
     cmds:
       - go build {{.BUILD_FLAGS}} -o {{.OUTPUT}}
     vars:
-      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app.Version=v{{.VERSION}}'
+      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app/types.Version=v{{.VERSION}}'
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s {{.LD_FLAGS}}"{{else}}-race -tags assert -buildvcs=false -gcflags=all="-l" -ldflags="{{.LD_FLAGS}}"{{end}}'
       DEFAULT_OUTPUT: '{{.BIN_DIR}}/{{.APP_NAME}}'
       OUTPUT: '{{ .OUTPUT | default .DEFAULT_OUTPUT }}'

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
     cmds:
       - go build {{.BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}
     vars:
-      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app.Version=v{{.VERSION}}'
+      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app/types.Version=v{{.VERSION}}'
 #      TODO: add -race back once it is fixed in Wails
 #      BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s {{.LD_FLAGS}}"{{else}}-race -tags assert -buildvcs=false -gcflags=all="-l" -ldflags="{{.LD_FLAGS}}"{{end}}'
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s {{.LD_FLAGS}}"{{else}} -tags assert -buildvcs=false -gcflags=all="-l" -ldflags="{{.LD_FLAGS}}"{{end}}'

--- a/build/windows/Taskfile.yml
+++ b/build/windows/Taskfile.yml
@@ -20,7 +20,7 @@ tasks:
       - cmd: rm -f *.syso
         platforms: [linux, darwin]
     vars:
-      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app.Version=v{{.VERSION}}'
+      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app/types.Version=v{{.VERSION}}'
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s {{.LD_FLAGS}} -H windowsgui"{{else}}-race -tags assert -buildvcs=false -gcflags=all="-l" -ldflags="{{.LD_FLAGS}}"{{end}}'
     env:
       GOOS: windows


### PR DESCRIPTION
## Summary
- Fixes LD_FLAGS to reference `backend/app/types.Version` instead of outdated `backend/app.Version` path (which was moved in commit 268b1db)
- Updates VERSION variable in root Taskfile to respect environment variables from CI while falling back to manifest for local builds
- Adds comprehensive version validation in build workflow to prevent releases with invalid versions (empty, 'dev', or 'v0.0.0')

## Problem
The v0.15.0 release was built with version `v0.0.0`, causing an endless update loop where the app continuously downloaded and restarted. This happened because:
1. The linker flags still referenced the old `backend/app.Version` path after it was refactored to `backend/app/types.Version`
2. The linker silently failed to set the version, leaving it at the default value
3. Task variables don't automatically use environment variables, so CI-provided VERSION was ignored

## Solution
- Update all platform Taskfiles (Linux, Darwin, Windows) to use correct linker flag path
- Make VERSION variable respect environment variables from GitHub Actions
- Add early validation step in CI to fail fast on invalid versions

## Testing
Verified with dry runs:
- `VERSION=9.9.9 task build --dry` → Uses env var correctly
- `task build --dry` → Falls back to manifest (0.15.0)