### PR TITLE
fix(build): prevent double 'v' prefix in version string

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,7 +14,9 @@ vars:
   BIN_DIR: "bin"
   VITE_PORT: '{{.WAILS_VITE_PORT | default 9245}}'
   VERSION:
-    sh: echo "${VERSION:-$(sed -n 's/.*"\."\s*:\s*"\([0-9.]*\)".*/\1/p' .release-please-manifest.json)}"
+    sh: |
+      VERSION_VALUE="${VERSION:-$(sed -n 's/.*"\."\s*:\s*"\([0-9.]*\)".*/\1/p' .release-please-manifest.json)}"
+      echo "${VERSION_VALUE#v}"
 
 tasks:
   build:


### PR DESCRIPTION
## Summary
- Strips 'v' prefix from VERSION variable before using in LD_FLAGS to prevent 'vv0.15.1' in binary
- Fixes issue where release-please passes version with 'v' prefix (e.g., `v0.15.1`) and LD_FLAGS also adds 'v'
- Works correctly whether VERSION is provided with or without 'v' prefix

## Problem
After PR #191, release-please passes `tag_name: v0.15.1` to the build workflow, which sets `VERSION=v0.15.1`. The LD_FLAGS then adds another 'v' prefix, resulting in `Version=vv0.15.1` in the compiled binary.

## Solution
Use shell parameter expansion `${VERSION_VALUE#v}` in Taskfile.yml to strip any leading 'v' before the LD_FLAGS adds it.

## Verified Behavior
- `VERSION=v9.9.9` → `Version=v9.9.9` ✅
- `VERSION=8.8.8` → `Version=v8.8.8` ✅  
- No VERSION (manifest) → `Version=v0.15.1` ✅