### PR TITLE
fix(build): eliminate race condition in darwin universal build

### DIFF
--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -26,18 +26,38 @@ tasks:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
       PRODUCTION: '{{.PRODUCTION | default "false"}}'
 
+  build:arch:
+    desc: Build for specific architecture (internal task)
+    internal: true
+    cmds:
+      - go build {{.BUILD_FLAGS}} -o {{.OUTPUT}}
+    vars:
+      LD_FLAGS: '-X github.com/loomi-labs/arco/backend/app/types.Version=v{{.VERSION}}'
+      BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s {{.LD_FLAGS}}"{{else}}-race -tags assert -buildvcs=false -gcflags=all="-l" -ldflags="{{.LD_FLAGS}}"{{end}}'
+    env:
+      GOOS: darwin
+      CGO_ENABLED: 1
+      GOARCH: '{{.ARCH}}'
+      CGO_CFLAGS: "-mmacosx-version-min=10.15"
+      CGO_LDFLAGS: "-mmacosx-version-min=10.15"
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      PRODUCTION: '{{.PRODUCTION | default "false"}}'
+
   build:universal:
     desc: Builds darwin universal binary (arm64 + amd64)
     deps:
-      - task: build
+      - task: common:go:mod:tidy
+      - task: common:build:frontend
+      - task: common:generate:icons
+    cmds:
+      - task: build:arch
         vars:
           ARCH: amd64
           OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-amd64"
-      - task: build
+      - task: build:arch
         vars:
           ARCH: arm64
           OUTPUT: "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
-    cmds:
       - lipo -create -output "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
       - rm "{{.BIN_DIR}}/{{.APP_NAME}}-amd64" "{{.BIN_DIR}}/{{.APP_NAME}}-arm64"
 


### PR DESCRIPTION
## Summary
- Fixes intermittent macOS build failures caused by race condition in universal binary build
- Refactors `build:universal` to build shared resources (frontend, icons, bindings) once before architecture builds
- Creates internal `build:arch` task for architecture-specific Go compilation only

## Root Cause
The darwin/universal build creates fat binaries by building both amd64 and arm64 architectures. Previously:
1. Both architecture builds ran as parallel dependencies
2. Each triggered `common:build:frontend` independently
3. Two concurrent pnpm processes raced to write to `frontend/dist`
4. File conflicts caused intermittent build failures

## Solution
```yaml
build:universal:
  deps:
    - common:build:frontend  # Build once here
    - common:generate:icons
    - common:go:mod:tidy
  cmds:
    - task: build:arch       # Then build amd64
    - task: build:arch       # Then build arm64
    - lipo -create ...       # Combine
```

The frontend is now built **once** before any architecture-specific builds start.

## Why Linux Builds Never Failed
Linux builds only create a single binary (not universal), so they never had concurrent builds racing.

## Testing
Verified with `task build --dry PRODUCTION=true PLATFORM=darwin/universal`:
- ✅ Frontend built once
- ✅ Architecture builds execute sequentially after shared resources ready
- ✅ No concurrent writes to frontend/dist