### PR TITLE
fix: update macFUSE URL from osxfuse to macfuse

### DIFF
--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -197,9 +197,9 @@ func (a *App) Startup(ctx context.Context) {
 	if platform.IsMacOS() && !platform.IsMacFUSEInstalled() {
 		a.log.Warn("macFUSE is not installed")
 		a.state.SetStartupStatus(a.ctx, a.state.GetStartupState().Status,
-			fmt.Errorf("macFUSE is required for Arco to function. Please install it from https://osxfuse.github.io and restart Arco"))
+			fmt.Errorf("macFUSE is required for Arco to function. Please install it from https://macfuse.github.io and restart Arco"))
 		// Open download page
-		_ = browser.OpenURL("https://osxfuse.github.io")
+		_ = browser.OpenURL("https://macfuse.github.io")
 		return // Stop startup but keep app open showing error
 	}
 


### PR DESCRIPTION
## Summary
- Update macFUSE download URL from old `osxfuse.github.io` to current `macfuse.github.io`

The OSXFUSE project was renamed to macFUSE and moved to a new URL. This updates both the error message and browser open URL to point users to the correct download page.

## Test plan
- [ ] Verify the URL opens the correct macFUSE download page