### PR TITLE
fix(keyring): don't close shared dbus session connection

### DIFF
--- a/backend/internal/keyring/keyring.go
+++ b/backend/internal/keyring/keyring.go
@@ -106,11 +106,10 @@ func getDefaultSecretServiceCollection(log *zap.SugaredLogger) string {
 		log.Infof("Failed to connect to D-Bus session bus: %v", err)
 		return ""
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Infof("Failed to close D-Bus connection: %v", err)
-		}
-	}()
+	// Note: Do NOT close the session bus connection here.
+	// dbus.SessionBus() returns a shared singleton connection.
+	// Closing it would terminate the connection for the entire process,
+	// including the Wails systray which uses it for StatusNotifierItem.
 
 	obj := conn.Object("org.freedesktop.secrets", "/org/freedesktop/secrets")
 	var path dbus.ObjectPath


### PR DESCRIPTION
## Summary
- Fix systray errors when starting app with `--hidden` flag on Linux
- `dbus.SessionBus()` returns a shared singleton connection that should not be closed
- Closing it terminated the connection for the entire process, breaking the Wails systray

## Root Cause
Commit fb01e75 introduced keyring functionality that queries D-Bus. The code incorrectly closed the shared session bus connection with `defer conn.Close()`, which also closed the connection used by the Wails systray for StatusNotifierItem.