### PR TITLE
fix: add IdentitiesOnly to SSH options to prevent auth failures

### DIFF
--- a/backend/borg/borg.go
+++ b/backend/borg/borg.go
@@ -150,6 +150,7 @@ func (e Env) AsList() []string {
 		"-oBatchMode=yes",
 		"-oStrictHostKeyChecking=accept-new",
 		"-oConnectTimeout=10",
+		"-oIdentitiesOnly=yes", // Only use specified keys, ignore SSH agent
 	}
 	for _, key := range e.sshPrivateKeys {
 		sshOptions = append(sshOptions, fmt.Sprintf("-i \"%s\"", key))


### PR DESCRIPTION
When users have many SSH keys or an SSH agent with multiple keys loaded, SSH tries each key in order. This can cause "Too many authentication failures" errors before the correct key (e.g., ArcoCloud key) is tried.

Adding -oIdentitiesOnly=yes ensures SSH only uses the explicitly specified identity files and ignores keys from the SSH agent.