### PR TITLE
fix(linux): remove version from package filenames

### DIFF
--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -86,8 +86,7 @@ tasks:
     desc: Creates a deb package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format deb -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - ls -la {{.ROOT_DIR}}/bin/
-      - sh -c 'mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}_*.deb {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}_amd64.deb'
+      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.deb {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}_amd64.deb
     env:
       VERSION: '{{.VERSION}}'
 
@@ -95,7 +94,7 @@ tasks:
     desc: Creates a rpm package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format rpm -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - sh -c 'mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}-*.rpm {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.x86_64.rpm'
+      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.rpm {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.x86_64.rpm
     env:
       VERSION: '{{.VERSION}}'
 
@@ -103,7 +102,7 @@ tasks:
     desc: Creates a arch linux packager package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format archlinux -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - sh -c 'mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}-*.pkg.tar.zst {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}-x86_64.pkg.tar.zst'
+      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.pkg.tar.zst {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}-x86_64.pkg.tar.zst
     env:
       VERSION: '{{.VERSION}}'
 


### PR DESCRIPTION
## Summary
- Simplify Linux package filenames by removing version numbers
- Package names now: `arco_amd64.deb`, `arco.x86_64.rpm`, `arco-x86_64.pkg.tar.zst`
- Adds rename step after each package generation in Taskfile