### PR TITLE
fix(linux): simplify package naming without version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,11 +270,10 @@ jobs:
           cd ./bin
           # Create zip for manual install
           zip -j "../arco-linux.zip" arco
-          # Rename packages with version
-          VERSION="${{ inputs.version || 'dev' }}"
-          mv arco.deb "arco-${VERSION}-linux-amd64.deb" 2>/dev/null || true
-          mv arco.rpm "arco-${VERSION}-linux-amd64.rpm" 2>/dev/null || true
-          mv arco.pkg.tar.zst "arco-${VERSION}-linux-amd64.pkg.tar.zst" 2>/dev/null || true
+          # Rename packages for release
+          mv arco.deb "arco-linux-amd64.deb" 2>/dev/null || true
+          mv arco.rpm "arco-linux-amd64.rpm" 2>/dev/null || true
+          mv arco.pkg.tar.zst "arco-linux-amd64.pkg.tar.zst" 2>/dev/null || true
 
       # Upload build assets
       - name: Upload build artifacts (Linux)
@@ -284,9 +283,9 @@ jobs:
           name: arco-linux
           path: |
             arco-linux.zip
-            bin/arco-*-linux-*.deb
-            bin/arco-*-linux-*.rpm
-            bin/arco-*-linux-*.pkg.tar.zst
+            bin/arco-linux-amd64.deb
+            bin/arco-linux-amd64.rpm
+            bin/arco-linux-amd64.pkg.tar.zst
           retention-days: 30
 
       - name: Upload build artifacts (macOS)
@@ -307,9 +306,9 @@ jobs:
           tag_name: ${{ inputs.version }}
           files: |
             arco-linux.zip
-            bin/arco-${{ inputs.version }}-linux-amd64.deb
-            bin/arco-${{ inputs.version }}-linux-amd64.rpm
-            bin/arco-${{ inputs.version }}-linux-amd64.pkg.tar.zst
+            bin/arco-linux-amd64.deb
+            bin/arco-linux-amd64.rpm
+            bin/arco-linux-amd64.pkg.tar.zst
           draft: false
           prerelease: false
 

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -86,7 +86,6 @@ tasks:
     desc: Creates a deb package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format deb -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.deb {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}_amd64.deb
     env:
       VERSION: '{{.VERSION}}'
 
@@ -94,7 +93,6 @@ tasks:
     desc: Creates a rpm package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format rpm -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.rpm {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.x86_64.rpm
     env:
       VERSION: '{{.VERSION}}'
 
@@ -102,7 +100,6 @@ tasks:
     desc: Creates a arch linux packager package
     cmds:
       - go tool wails3 tool package -name {{.BINARY_NAME}} -format archlinux -config ./build/linux/nfpm/nfpm.yaml -out {{.ROOT_DIR}}/bin
-      - mv {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}.pkg.tar.zst {{.ROOT_DIR}}/bin/{{.BINARY_NAME}}-x86_64.pkg.tar.zst
     env:
       VERSION: '{{.VERSION}}'
 


### PR DESCRIPTION
## Summary
- Remove version from Linux package release asset names
- Package names: `arco-linux-amd64.deb`, `arco-linux-amd64.rpm`, `arco-linux-amd64.pkg.tar.zst`
- Fixes release upload issue where versioned filenames didn't match actual output