### PR TITLE
feat: upgrade borg to 1.4.5

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -34,16 +34,16 @@ jobs:
       matrix:
         include:
           # Latest borg on all Ubuntu versions
-          - borg-version: "1.4.4"
+          - borg-version: "1.4.5"
             base-image: "ubuntu-20.04"
             arch: "amd64"
-          - borg-version: "1.4.4"
+          - borg-version: "1.4.5"
             base-image: "ubuntu-22.04"
             arch: "amd64"
-          - borg-version: "1.4.4"
+          - borg-version: "1.4.5"
             base-image: "ubuntu-24.04"
             arch: "amd64"
-          - borg-version: "1.4.4"
+          - borg-version: "1.4.5"
             base-image: "ubuntu-24.04"
             arch: "arm64"
           # Older borg versions on Ubuntu 24.04 only
@@ -117,20 +117,20 @@ jobs:
         include:
           # Latest borg on all Ubuntu versions
           - os: ubuntu-latest
-            borg-version: "1.4.4"
+            borg-version: "1.4.5"
             base-image: ubuntu-20.04
             arch: amd64
           - os: ubuntu-latest
-            borg-version: "1.4.4"
+            borg-version: "1.4.5"
             base-image: ubuntu-22.04
             arch: amd64
           - os: ubuntu-24.04
-            borg-version: "1.4.4"
+            borg-version: "1.4.5"
             base-image: ubuntu-24.04
             arch: amd64
           # ARM64 tests on native runner
           - os: ubuntu-24.04-arm
-            borg-version: "1.4.4"
+            borg-version: "1.4.5"
             base-image: ubuntu-24.04
             arch: arm64
           # Older borg versions on Ubuntu 24.04 only

--- a/backend/platform/borg.go
+++ b/backend/platform/borg.go
@@ -12,6 +12,46 @@ import (
 
 // Binaries contains all available Borg binary variants
 var Binaries = []BorgBinary{
+	// Borg 1.4.5 - Linux x86_64 (glibc231 build was dropped upstream in 1.4.5; min glibc is now 2.35)
+	{
+		Name:          "borg_1.4.5",
+		Version:       version.Must(version.NewVersion("1.4.5")),
+		Os:            Linux,
+		GlibcVersion:  version.Must(version.NewVersion("2.35")),
+		Arch:          "amd64",
+		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-x86_64-gh",
+		SupportsMount: true,
+	},
+	// Borg 1.4.5 - Linux ARM64
+	{
+		Name:          "borg_1.4.5",
+		Version:       version.Must(version.NewVersion("1.4.5")),
+		Os:            Linux,
+		GlibcVersion:  version.Must(version.NewVersion("2.35")),
+		Arch:          "arm64",
+		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-arm64-gh",
+		SupportsMount: true,
+	},
+	// Borg 1.4.5 - macOS Intel (directory distribution for faster startup, no FUSE support)
+	{
+		Name:          "borg_1.4.5",
+		Version:       version.Must(version.NewVersion("1.4.5")),
+		Os:            Darwin,
+		Arch:          "amd64",
+		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-x86_64-gh.tgz",
+		IsDirectory:   true,
+		SupportsMount: false, // -gh builds don't include llfuse
+	},
+	// Borg 1.4.5 - macOS Apple Silicon (directory distribution for faster startup, no FUSE support)
+	{
+		Name:          "borg_1.4.5",
+		Version:       version.Must(version.NewVersion("1.4.5")),
+		Os:            Darwin,
+		Arch:          "arm64",
+		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-arm64-gh.tgz",
+		IsDirectory:   true,
+		SupportsMount: false, // -gh builds don't include llfuse
+	},
 	// Borg 1.4.4 - Linux x86_64 variants
 	{
 		Name:          "borg_1.4.4",
@@ -227,35 +267,12 @@ func GetLatestBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 		return selectLowestGlibcBinary(binaries, currentArch), nil
 	}
 
-	// 5. Compare GLIBC versions -> select highest version that is <= system GLIBC version
-	var bestBinary BorgBinary
-	var bestGlibcVersion *version.Version
-
-	for _, binary := range binaries {
-		// Only consider binaries for current OS, architecture, and latest Borg version
-		if binary.Os != currentOS || !binary.Version.Equal(latestVersion) {
-			continue
-		}
-
-		// Check architecture compatibility (empty means any)
-		if binary.Arch != "" && binary.Arch != currentArch {
-			continue
-		}
-
-		if binary.GlibcVersion != nil && binary.GlibcVersion.LessThanOrEqual(systemGlibc) {
-			if bestGlibcVersion == nil || binary.GlibcVersion.GreaterThan(bestGlibcVersion) {
-				bestBinary = binary
-				bestGlibcVersion = binary.GlibcVersion
-			}
-		}
-	}
-
-	if bestGlibcVersion == nil {
-		// No compatible GLIBC version found, return lowest available
-		return selectLowestGlibcBinary(binaries, currentArch), nil
-	}
-
-	return bestBinary, nil
+	// 5. Select the highest Borg version whose glibc requirement the system satisfies.
+	// This intentionally looks across all versions rather than only the newest one: upstream
+	// occasionally drops a glibc build for the latest version (e.g. 1.4.5 dropped glibc231),
+	// so a system on an older glibc should fall back to the newest still-compatible version
+	// (1.4.4-glibc231) instead of the globally-oldest build.
+	return selectBestGlibcBinary(binaries, currentArch, systemGlibc, false), nil
 }
 
 // getGlibcVersion detects the system's GLIBC version on Linux systems
@@ -380,35 +397,8 @@ func GetMountBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 		return selectLowestGlibcMountBinary(binaries, currentArch), nil
 	}
 
-	// Compare GLIBC versions -> select highest version that is <= system GLIBC version
-	var bestBinary BorgBinary
-	var bestGlibcVersion *version.Version
-
-	for _, binary := range binaries {
-		// Only consider binaries for current OS, latest Borg version, and mount support
-		if binary.Os != currentOS || !binary.Version.Equal(latestVersion) || !binary.SupportsMount {
-			continue
-		}
-
-		// Check architecture compatibility (empty means any)
-		if binary.Arch != "" && binary.Arch != currentArch {
-			continue
-		}
-
-		if binary.GlibcVersion != nil && binary.GlibcVersion.LessThanOrEqual(systemGlibc) {
-			if bestGlibcVersion == nil || binary.GlibcVersion.GreaterThan(bestGlibcVersion) {
-				bestBinary = binary
-				bestGlibcVersion = binary.GlibcVersion
-			}
-		}
-	}
-
-	if bestGlibcVersion == nil {
-		// No compatible GLIBC version found, return lowest available with mount support
-		return selectLowestGlibcMountBinary(binaries, currentArch), nil
-	}
-
-	return bestBinary, nil
+	// Select the highest mount-capable Borg version whose glibc requirement the system satisfies.
+	return selectBestGlibcBinary(binaries, currentArch, systemGlibc, true), nil
 }
 
 // selectLowestGlibcMountBinary returns the binary with the lowest GLIBC requirement that supports mount
@@ -442,4 +432,59 @@ func selectLowestGlibcMountBinary(binaries []BorgBinary, arch string) BorgBinary
 	}
 
 	return lowest
+}
+
+// selectBestGlibcBinary picks the best Linux binary for the given architecture and system glibc
+// version. It returns the highest Borg version whose glibc requirement is satisfied by the system
+// (GlibcVersion <= systemGlibc), breaking ties toward the higher glibc build. When mountOnly is
+// set, only mount-capable binaries are considered.
+//
+// Unlike a "newest version, then filter by glibc" approach, this searches across all versions so
+// that a system on an older glibc still gets the newest compatible version even when the latest
+// release dropped a glibc build (e.g. 1.4.5 dropped the x86_64 glibc231 build). If the system
+// glibc is older than every available build, it falls back to the lowest-glibc binary.
+func selectBestGlibcBinary(binaries []BorgBinary, arch string, systemGlibc *version.Version, mountOnly bool) BorgBinary {
+	var best BorgBinary
+	found := false
+
+	for _, binary := range binaries {
+		if binary.Os != Linux {
+			continue
+		}
+
+		// Check architecture compatibility (empty means any)
+		if binary.Arch != "" && binary.Arch != arch {
+			continue
+		}
+
+		if mountOnly && !binary.SupportsMount {
+			continue
+		}
+
+		if binary.GlibcVersion == nil {
+			continue
+		}
+
+		// Skip builds that require a newer glibc than the system provides
+		if binary.GlibcVersion.GreaterThan(systemGlibc) {
+			continue
+		}
+
+		if !found ||
+			binary.Version.GreaterThan(best.Version) ||
+			(binary.Version.Equal(best.Version) && binary.GlibcVersion.GreaterThan(best.GlibcVersion)) {
+			best = binary
+			found = true
+		}
+	}
+
+	if !found {
+		// System glibc is older than every available build; return the lowest-glibc option.
+		if mountOnly {
+			return selectLowestGlibcMountBinary(binaries, arch)
+		}
+		return selectLowestGlibcBinary(binaries, arch)
+	}
+
+	return best
 }

--- a/backend/platform/borg.go
+++ b/backend/platform/borg.go
@@ -156,6 +156,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.1")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.28")),
+		Arch:          "amd64", // upstream 1.4.1 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc228",
 		SupportsMount: true,
 	},
@@ -164,6 +165,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.1")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.31")),
+		Arch:          "amd64", // upstream 1.4.1 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc231",
 		SupportsMount: true,
 	},
@@ -172,6 +174,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.1")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.36")),
+		Arch:          "amd64", // upstream 1.4.1 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc236",
 		SupportsMount: true,
 	},
@@ -190,6 +193,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.0")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.28")),
+		Arch:          "amd64", // upstream 1.4.0 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.0/borg-linux-glibc228",
 		SupportsMount: true,
 	},
@@ -198,6 +202,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.0")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.31")),
+		Arch:          "amd64", // upstream 1.4.0 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.0/borg-linux-glibc231",
 		SupportsMount: true,
 	},
@@ -206,6 +211,7 @@ var Binaries = []BorgBinary{
 		Version:       version.Must(version.NewVersion("1.4.0")),
 		Os:            Linux,
 		GlibcVersion:  version.Must(version.NewVersion("2.36")),
+		Arch:          "amd64", // upstream 1.4.0 fat binaries are x86_64-only (no official arm64 build)
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.0/borg-linux-glibc236",
 		SupportsMount: true,
 	},

--- a/backend/platform/borg_test.go
+++ b/backend/platform/borg_test.go
@@ -67,13 +67,14 @@ func TestSelectBestGlibcBinary(t *testing.T) {
 			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-arm64-gh",
 		},
 		{
-			// arm64 has no glibc231 build; a 2.29 arm64 system falls back across versions to
-			// the newest build whose glibc fits (1.4.1-glibc228, a universal/empty-Arch build).
-			name:        "glibc 2.29 arm64 -> newest compatible universal fallback",
+			// No arm64 build exists below glibc 2.35, and the old fat binaries are x86_64-only.
+			// An arm64 host must never be handed an x86_64 binary: it falls back to the
+			// lowest-glibc arm64 build rather than a glibc228 x86_64 one.
+			name:        "glibc 2.29 arm64 -> arm64 build only, never x86_64 fallback",
 			arch:        "arm64",
 			systemGlibc: "2.29",
-			wantName:    "borg_1.4.1",
-			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc228",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-arm64-gh",
 		},
 	}
 
@@ -85,6 +86,11 @@ func TestSelectBestGlibcBinary(t *testing.T) {
 			}
 			if got.Url != tt.wantURL {
 				t.Errorf("Url = %q, want %q", got.Url, tt.wantURL)
+			}
+			// A binary with an explicit Arch must never be selected for a different arch
+			// (e.g. an arm64 host must not receive an x86_64-only build).
+			if got.Arch != "" && got.Arch != tt.arch {
+				t.Errorf("selected Arch = %q for %q host", got.Arch, tt.arch)
 			}
 		})
 	}

--- a/backend/platform/borg_test.go
+++ b/backend/platform/borg_test.go
@@ -1,0 +1,91 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+)
+
+func mustVersion(t *testing.T, s string) *version.Version {
+	t.Helper()
+	v, err := version.NewVersion(s)
+	if err != nil {
+		t.Fatalf("failed to parse version %q: %v", s, err)
+	}
+	return v
+}
+
+// TestSelectBestGlibcBinary verifies that the newest Borg version compatible with the
+// system glibc is selected, including the fallback when the latest release dropped a
+// glibc build (1.4.5 dropped the x86_64 glibc231 build).
+func TestSelectBestGlibcBinary(t *testing.T) {
+	tests := []struct {
+		name        string
+		arch        string
+		systemGlibc string
+		mountOnly   bool
+		wantName    string
+		wantURL     string
+	}{
+		{
+			name:        "modern glibc amd64 -> 1.4.5 glibc235",
+			arch:        "amd64",
+			systemGlibc: "2.40",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-x86_64-gh",
+		},
+		{
+			name:        "exactly glibc 2.35 amd64 -> 1.4.5 glibc235",
+			arch:        "amd64",
+			systemGlibc: "2.35",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-x86_64-gh",
+		},
+		{
+			// The regression fix: 1.4.5 has no glibc231 build, so a glibc 2.33 system
+			// must fall back to the newest still-compatible version (1.4.4-glibc231),
+			// NOT the globally-oldest build (1.4.1-glibc228).
+			name:        "glibc 2.33 amd64 -> 1.4.4 glibc231 (regression fix)",
+			arch:        "amd64",
+			systemGlibc: "2.33",
+			wantName:    "borg_1.4.4",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.4/borg-linux-glibc231-x86_64",
+		},
+		{
+			// Older than every glibc231/235 build -> lowest-glibc fallback (glibc228).
+			name:        "glibc 2.29 amd64 -> lowest glibc fallback",
+			arch:        "amd64",
+			systemGlibc: "2.29",
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc228",
+		},
+		{
+			name:        "modern glibc arm64 -> 1.4.5 glibc235 arm64",
+			arch:        "arm64",
+			systemGlibc: "2.40",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-linux-glibc235-arm64-gh",
+		},
+		{
+			// arm64 has no glibc231 build; a 2.29 arm64 system falls back across versions to
+			// the newest build whose glibc fits (1.4.1-glibc228, a universal/empty-Arch build).
+			name:        "glibc 2.29 arm64 -> newest compatible universal fallback",
+			arch:        "arm64",
+			systemGlibc: "2.29",
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-linux-glibc228",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectBestGlibcBinary(Binaries, tt.arch, mustVersion(t, tt.systemGlibc), tt.mountOnly)
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Url != tt.wantURL {
+				t.Errorf("Url = %q, want %q", got.Url, tt.wantURL)
+			}
+		})
+	}
+}

--- a/docker/borg-client/ubuntu-20.04.Dockerfile
+++ b/docker/borg-client/ubuntu-20.04.Dockerfile
@@ -38,8 +38,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
 # Re-declare build arguments
-ARG CLIENT_BORG_VERSION=1.4.4
-ARG SERVER_BORG_VERSION=1.4.4
+ARG CLIENT_BORG_VERSION=1.4.5
+ARG SERVER_BORG_VERSION=1.4.5
 
 # Install required packages. Ship both FUSE generations: FUSE 2 (fusermount +
 # libfuse.so.2) for llfuse-based Borg builds and FUSE 3 (fusermount3 +

--- a/docker/borg-client/ubuntu-22.04.Dockerfile
+++ b/docker/borg-client/ubuntu-22.04.Dockerfile
@@ -32,8 +32,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -tags integration -o /arco-cli ./backend/c
 FROM ubuntu:22.04
 
 # Global build arguments
-ARG CLIENT_BORG_VERSION=1.4.4
-ARG SERVER_BORG_VERSION=1.4.4
+ARG CLIENT_BORG_VERSION=1.4.5
+ARG SERVER_BORG_VERSION=1.4.5
 
 # Install required packages including Docker client and FUSE for mount operations
 # Ship both FUSE generations: FUSE 2 (fusermount + libfuse.so.2) for llfuse-based

--- a/docker/borg-client/ubuntu-24.04.Dockerfile
+++ b/docker/borg-client/ubuntu-24.04.Dockerfile
@@ -32,8 +32,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -tags integration -o /arco-cli ./backend/c
 FROM ubuntu:24.04
 
 # Global build arguments
-ARG CLIENT_BORG_VERSION=1.4.4
-ARG SERVER_BORG_VERSION=1.4.4
+ARG CLIENT_BORG_VERSION=1.4.5
+ARG SERVER_BORG_VERSION=1.4.5
 
 # Install required packages including Docker client and FUSE for mount operations
 # Ship both FUSE generations: FUSE 2 (fusermount + libfuse.so.2) for llfuse-based

--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -42,9 +42,9 @@ print_usage() {
     echo "Examples:"
     echo "  $0 --client-version 1.4.0 --server-version 1.4.0"
     echo "  $0 --client-version 1.4.1 --server-version 1.4.1 --base-image ubuntu:22.04"
-    echo "  $0 --client-version 1.4.4 --server-version 1.4.4"
-    echo "  $0 --client-version 1.4.4 --server-version 1.4.4 --verbose"
-    echo "  $0 --client-version 1.4.4 --server-version 1.4.4 -- -run TestBorgMountOperations -v"
+    echo "  $0 --client-version 1.4.5 --server-version 1.4.5"
+    echo "  $0 --client-version 1.4.5 --server-version 1.4.5 --verbose"
+    echo "  $0 --client-version 1.4.5 --server-version 1.4.5 -- -run TestBorgMountOperations -v"
 }
 
 log_info() {


### PR DESCRIPTION
## Summary
- Add Borg **1.4.5** binaries (Linux amd64/arm64 glibc235, macOS amd64/arm64 `.tgz`) and make it the default version.
- **Fix a selection regression**: 1.4.5 dropped the x86_64 `glibc231` build, so the newest Borg now requires glibc ≥ 2.35. The binary-selection fallback now picks the newest *still-compatible* version (→ 1.4.4-glibc231) for systems on glibc 2.31–2.34, instead of the globally-oldest build (1.4.1). Selection logic refactored into a testable `selectBestGlibcBinary` helper (used by both `GetLatestBorgBinary` and `GetMountBorgBinary`).
- Add `backend/platform/borg_test.go` covering the fallback, including the regression case.
- Bump version labels in the Docker client images, CI matrix, and test script.

## Notes
- No Borg repo-format change (still 1.4) — no data migration. Includes a low-severity fix for CVE-2026-62268.
- Version labels in Docker/CI are cosmetic: both client and server download Borg dynamically via `arco-cli --show-borg-url`. On the glibc-2.31 CI row (ubuntu-20.04), the client resolves to 1.4.4-glibc231 by design.