### PR TITLE
chore(mcp): reorder server entries in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,17 @@
 {
   "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "linear": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.linear.app/mcp"
+      ]
+    },
     "sqlite": {
       "command": "uv",
       "args": [
@@ -10,18 +22,6 @@
         "--db-path",
         "${HOME}/.config/arco/arco.db"
       ]
-    },
-    "linear": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.linear.app/mcp"
-      ]
-    },
-    "context7": {
-      "type": "http",
-      "url": "https://mcp.context7.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Reorder the MCP server entries in `.mcp.json` (context7 and linear now listed above sqlite).

Cosmetic ordering change only — no functional impact.