### PR TITLE
feat(settings): add font size and high contrast options

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,13 @@
 {
   "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://mcp.linear.app/mcp"
+      ]
+    },
     "sqlite": {
       "command": "uv",
       "args": [
@@ -10,18 +18,6 @@
         "--db-path",
         "${HOME}/.config/arco/arco.db"
       ]
-    },
-    "linear": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.linear.app/mcp"
-      ]
-    },
-    "context7": {
-      "type": "http",
-      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/backend/app/user/client.go
+++ b/backend/app/user/client.go
@@ -103,6 +103,8 @@ func (s *Service) SaveSettings(ctx context.Context, settings *ent.Settings) erro
 		SetTheme(settings.Theme).
 		SetDisableTransitions(settings.DisableTransitions).
 		SetDisableShadows(settings.DisableShadows).
+		SetFontScale(settings.FontScale).
+		SetHighContrast(settings.HighContrast).
 		Exec(ctx)
 	if err != nil {
 		return err

--- a/backend/ent/migrate/migrate_test.go
+++ b/backend/ent/migrate/migrate_test.go
@@ -50,6 +50,7 @@ var migrationValidators = map[string]func(t *testing.T, ctx context.Context, db 
 	"20260202123657_gen": validateIntervalMinutes,
 	"20260327153722_gen": validateFeedbackPrompt,
 	"20260331130829_gen": validateAnalytics,
+	"20260721133129_add_font_scale_and_high_contrast": validateFontScaleAndHighContrast,
 }
 
 // TestMigrationCoverage ensures every migration file has a registered validator.
@@ -1005,6 +1006,22 @@ func validateAnalytics(t *testing.T, ctx context.Context, db *sql.DB, client *en
 	// Verify sent index exists.
 	if !indexExists(t, db, "analytics_events", "sent") {
 		t.Error("index on sent column should exist on analytics_events")
+	}
+}
+
+// validateFontScaleAndHighContrast checks that font_scale and high_contrast were added with defaults.
+func validateFontScaleAndHighContrast(t *testing.T, ctx context.Context, _ *sql.DB, client *ent.Client) {
+	t.Helper()
+
+	settings, err := client.Settings.Query().Only(ctx)
+	if err != nil {
+		t.Fatalf("failed to query settings: %v", err)
+	}
+	if settings.FontScale != 100 {
+		t.Errorf("font_scale should default to 100, got %d", settings.FontScale)
+	}
+	if settings.HighContrast != false {
+		t.Error("high_contrast should default to false")
 	}
 }
 

--- a/backend/ent/migrate/migrations/20260721133129_add_font_scale_and_high_contrast.sql
+++ b/backend/ent/migrate/migrations/20260721133129_add_font_scale_and_high_contrast.sql
@@ -1,0 +1,27 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_settings" table
+CREATE TABLE `new_settings` (
+  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `expert_mode` bool NOT NULL DEFAULT false,
+  `theme` text NOT NULL DEFAULT 'system',
+  `disable_transitions` bool NOT NULL DEFAULT false,
+  `disable_shadows` bool NOT NULL DEFAULT false,
+  `macfuse_warning_dismissed` bool NOT NULL DEFAULT false,
+  `full_disk_access_warning_dismissed` bool NOT NULL DEFAULT false,
+  `feedback_last_prompted_at` datetime NULL,
+  `usage_logging_enabled` bool NULL,
+  `installation_id` uuid NOT NULL,
+  `font_scale` integer NOT NULL DEFAULT 100,
+  `high_contrast` bool NOT NULL DEFAULT false
+);
+-- Copy rows from old table "settings" to new temporary table "new_settings"
+INSERT INTO `new_settings` (`id`, `created_at`, `updated_at`, `expert_mode`, `theme`, `disable_transitions`, `disable_shadows`, `macfuse_warning_dismissed`, `full_disk_access_warning_dismissed`, `feedback_last_prompted_at`, `usage_logging_enabled`, `installation_id`) SELECT `id`, `created_at`, `updated_at`, `expert_mode`, `theme`, `disable_transitions`, `disable_shadows`, `macfuse_warning_dismissed`, `full_disk_access_warning_dismissed`, `feedback_last_prompted_at`, `usage_logging_enabled`, `installation_id` FROM `settings`;
+-- Drop "settings" table after copying rows
+DROP TABLE `settings`;
+-- Rename temporary table "new_settings" to "settings"
+ALTER TABLE `new_settings` RENAME TO `settings`;
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/backend/ent/migrate/migrations/atlas.sum
+++ b/backend/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:otQNijen+xxRmBdFhWrcbi/GR0WncmeQ64nUc9mfqwc=
+h1:8rR4d0/c/FC7ERrljX0RUn1QidR+qtyFHb9b/17tdLk=
 20241202145510_init.sql h1:3Vh7O+dfaLbEkPBEbxOcHIse/G5XcXsrUzXLphw9M0E=
 20241202193640_default_settings.sql h1:nCE2FptFxuRc8jN3RNrqp8OZWZuUluQqPRzwR+NLaW8=
 20250221150025_add_collapse_state.sql h1:DFoBihPNN1p/68mrP4iROI4VC+/DHwtj+BmGW4Os/3Y=
@@ -24,3 +24,4 @@ h1:otQNijen+xxRmBdFhWrcbi/GR0WncmeQ64nUc9mfqwc=
 20260202123657_gen.sql h1:lqglB/XK+9Ef4kIyTe7YRLeoxt9Gyuj1vsg7hsE2MMQ=
 20260327153722_gen.sql h1:VicsCrct9wZZG5CThrCAvNtr2HgxlA/w3JD3Jow1Z0U=
 20260331130829_gen.sql h1:im1ZlRXPbw5OVoLG2V/gsseNNdHf9ze1YEiXWztUOFU=
+20260721133129_add_font_scale_and_high_contrast.sql h1:jaHlytL7mrwJhNiE99KplkmLqrm241se6RACgCyCD7M=

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -271,6 +271,8 @@ var (
 		{Name: "feedback_last_prompted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "usage_logging_enabled", Type: field.TypeBool, Nullable: true},
 		{Name: "installation_id", Type: field.TypeUUID},
+		{Name: "font_scale", Type: field.TypeInt, Default: 100},
+		{Name: "high_contrast", Type: field.TypeBool, Default: false},
 	}
 	// SettingsTable holds the schema information for the "settings" table.
 	SettingsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -9271,6 +9271,9 @@ type SettingsMutation struct {
 	feedback_last_prompted_at          *time.Time
 	usage_logging_enabled              *bool
 	installation_id                    *uuid.UUID
+	font_scale                         *int
+	addfont_scale                      *int
+	high_contrast                      *bool
 	clearedFields                      map[string]struct{}
 	done                               bool
 	oldValue                           func(context.Context) (*Settings, error)
@@ -9797,6 +9800,98 @@ func (m *SettingsMutation) ResetInstallationID() {
 	m.installation_id = nil
 }
 
+// SetFontScale sets the "font_scale" field.
+func (m *SettingsMutation) SetFontScale(i int) {
+	m.font_scale = &i
+	m.addfont_scale = nil
+}
+
+// FontScale returns the value of the "font_scale" field in the mutation.
+func (m *SettingsMutation) FontScale() (r int, exists bool) {
+	v := m.font_scale
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFontScale returns the old "font_scale" field's value of the Settings entity.
+// If the Settings object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SettingsMutation) OldFontScale(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFontScale is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFontScale requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFontScale: %w", err)
+	}
+	return oldValue.FontScale, nil
+}
+
+// AddFontScale adds i to the "font_scale" field.
+func (m *SettingsMutation) AddFontScale(i int) {
+	if m.addfont_scale != nil {
+		*m.addfont_scale += i
+	} else {
+		m.addfont_scale = &i
+	}
+}
+
+// AddedFontScale returns the value that was added to the "font_scale" field in this mutation.
+func (m *SettingsMutation) AddedFontScale() (r int, exists bool) {
+	v := m.addfont_scale
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetFontScale resets all changes to the "font_scale" field.
+func (m *SettingsMutation) ResetFontScale() {
+	m.font_scale = nil
+	m.addfont_scale = nil
+}
+
+// SetHighContrast sets the "high_contrast" field.
+func (m *SettingsMutation) SetHighContrast(b bool) {
+	m.high_contrast = &b
+}
+
+// HighContrast returns the value of the "high_contrast" field in the mutation.
+func (m *SettingsMutation) HighContrast() (r bool, exists bool) {
+	v := m.high_contrast
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldHighContrast returns the old "high_contrast" field's value of the Settings entity.
+// If the Settings object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SettingsMutation) OldHighContrast(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldHighContrast is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldHighContrast requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldHighContrast: %w", err)
+	}
+	return oldValue.HighContrast, nil
+}
+
+// ResetHighContrast resets all changes to the "high_contrast" field.
+func (m *SettingsMutation) ResetHighContrast() {
+	m.high_contrast = nil
+}
+
 // Where appends a list predicates to the SettingsMutation builder.
 func (m *SettingsMutation) Where(ps ...predicate.Settings) {
 	m.predicates = append(m.predicates, ps...)
@@ -9831,7 +9926,7 @@ func (m *SettingsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SettingsMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 13)
 	if m.created_at != nil {
 		fields = append(fields, settings.FieldCreatedAt)
 	}
@@ -9865,6 +9960,12 @@ func (m *SettingsMutation) Fields() []string {
 	if m.installation_id != nil {
 		fields = append(fields, settings.FieldInstallationID)
 	}
+	if m.font_scale != nil {
+		fields = append(fields, settings.FieldFontScale)
+	}
+	if m.high_contrast != nil {
+		fields = append(fields, settings.FieldHighContrast)
+	}
 	return fields
 }
 
@@ -9895,6 +9996,10 @@ func (m *SettingsMutation) Field(name string) (ent.Value, bool) {
 		return m.UsageLoggingEnabled()
 	case settings.FieldInstallationID:
 		return m.InstallationID()
+	case settings.FieldFontScale:
+		return m.FontScale()
+	case settings.FieldHighContrast:
+		return m.HighContrast()
 	}
 	return nil, false
 }
@@ -9926,6 +10031,10 @@ func (m *SettingsMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldUsageLoggingEnabled(ctx)
 	case settings.FieldInstallationID:
 		return m.OldInstallationID(ctx)
+	case settings.FieldFontScale:
+		return m.OldFontScale(ctx)
+	case settings.FieldHighContrast:
+		return m.OldHighContrast(ctx)
 	}
 	return nil, fmt.Errorf("unknown Settings field %s", name)
 }
@@ -10012,6 +10121,20 @@ func (m *SettingsMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetInstallationID(v)
 		return nil
+	case settings.FieldFontScale:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFontScale(v)
+		return nil
+	case settings.FieldHighContrast:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetHighContrast(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Settings field %s", name)
 }
@@ -10019,13 +10142,21 @@ func (m *SettingsMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *SettingsMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addfont_scale != nil {
+		fields = append(fields, settings.FieldFontScale)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *SettingsMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case settings.FieldFontScale:
+		return m.AddedFontScale()
+	}
 	return nil, false
 }
 
@@ -10034,6 +10165,13 @@ func (m *SettingsMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *SettingsMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case settings.FieldFontScale:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddFontScale(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Settings numeric field %s", name)
 }
@@ -10108,6 +10246,12 @@ func (m *SettingsMutation) ResetField(name string) error {
 		return nil
 	case settings.FieldInstallationID:
 		m.ResetInstallationID()
+		return nil
+	case settings.FieldFontScale:
+		m.ResetFontScale()
+		return nil
+	case settings.FieldHighContrast:
+		m.ResetHighContrast()
 		return nil
 	}
 	return fmt.Errorf("unknown Settings field %s", name)

--- a/backend/ent/runtime.go
+++ b/backend/ent/runtime.go
@@ -344,6 +344,30 @@ func init() {
 	settingsDescInstallationID := settingsFields[8].Descriptor()
 	// settings.DefaultInstallationID holds the default value on creation for the installation_id field.
 	settings.DefaultInstallationID = settingsDescInstallationID.Default.(func() uuid.UUID)
+	// settingsDescFontScale is the schema descriptor for font_scale field.
+	settingsDescFontScale := settingsFields[9].Descriptor()
+	// settings.DefaultFontScale holds the default value on creation for the font_scale field.
+	settings.DefaultFontScale = settingsDescFontScale.Default.(int)
+	// settings.FontScaleValidator is a validator for the "font_scale" field. It is called by the builders before save.
+	settings.FontScaleValidator = func() func(int) error {
+		validators := settingsDescFontScale.Validators
+		fns := [...]func(int) error{
+			validators[0].(func(int) error),
+			validators[1].(func(int) error),
+		}
+		return func(font_scale int) error {
+			for _, fn := range fns {
+				if err := fn(font_scale); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}()
+	// settingsDescHighContrast is the schema descriptor for high_contrast field.
+	settingsDescHighContrast := settingsFields[10].Descriptor()
+	// settings.DefaultHighContrast holds the default value on creation for the high_contrast field.
+	settings.DefaultHighContrast = settingsDescHighContrast.Default.(bool)
 	userMixin := schema.User{}.Mixin()
 	userMixinFields0 := userMixin[0].Fields()
 	_ = userMixinFields0

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -5,6 +5,6 @@ package runtime
 // The schema-stitching logic is generated in github.com/loomi-labs/arco/backend/ent/runtime.go
 
 const (
-	Version = "v0.14.5"                                         // Version of ent codegen.
-	Sum     = "h1:Rj2WOYJtCkWyFo6a+5wB3EfBRP0rnx1fMk6gGA0UUe4=" // Sum of ent codegen.
+	Version = "v0.14.6"                                         // Version of ent codegen.
+	Sum     = "h1:/f2696BpwuWAEEG6PVGWflg6+Inrpq4pRWuNlWz/Skk=" // Sum of ent codegen.
 )

--- a/backend/ent/schema/settings.go
+++ b/backend/ent/schema/settings.go
@@ -50,6 +50,14 @@ func (Settings) Fields() []ent.Field {
 		field.UUID("installation_id", uuid.UUID{}).
 			StructTag(`json:"installationId"`).
 			Default(uuid.New),
+		field.Int("font_scale").
+			StructTag(`json:"fontScale"`).
+			Default(100).
+			Min(80).
+			Max(150),
+		field.Bool("high_contrast").
+			StructTag(`json:"highContrast"`).
+			Default(false),
 	}
 }
 

--- a/backend/ent/settings.go
+++ b/backend/ent/settings.go
@@ -40,7 +40,11 @@ type Settings struct {
 	UsageLoggingEnabled *bool `json:"usageLoggingEnabled"`
 	// InstallationID holds the value of the "installation_id" field.
 	InstallationID uuid.UUID `json:"installationId"`
-	selectValues   sql.SelectValues
+	// FontScale holds the value of the "font_scale" field.
+	FontScale int `json:"fontScale"`
+	// HighContrast holds the value of the "high_contrast" field.
+	HighContrast bool `json:"highContrast"`
+	selectValues sql.SelectValues
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -48,9 +52,9 @@ func (*Settings) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case settings.FieldExpertMode, settings.FieldDisableTransitions, settings.FieldDisableShadows, settings.FieldMacfuseWarningDismissed, settings.FieldFullDiskAccessWarningDismissed, settings.FieldUsageLoggingEnabled:
+		case settings.FieldExpertMode, settings.FieldDisableTransitions, settings.FieldDisableShadows, settings.FieldMacfuseWarningDismissed, settings.FieldFullDiskAccessWarningDismissed, settings.FieldUsageLoggingEnabled, settings.FieldHighContrast:
 			values[i] = new(sql.NullBool)
-		case settings.FieldID:
+		case settings.FieldID, settings.FieldFontScale:
 			values[i] = new(sql.NullInt64)
 		case settings.FieldTheme:
 			values[i] = new(sql.NullString)
@@ -147,6 +151,18 @@ func (_m *Settings) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				_m.InstallationID = *value
 			}
+		case settings.FieldFontScale:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field font_scale", values[i])
+			} else if value.Valid {
+				_m.FontScale = int(value.Int64)
+			}
+		case settings.FieldHighContrast:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field high_contrast", values[i])
+			} else if value.Valid {
+				_m.HighContrast = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -219,6 +235,12 @@ func (_m *Settings) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("installation_id=")
 	builder.WriteString(fmt.Sprintf("%v", _m.InstallationID))
+	builder.WriteString(", ")
+	builder.WriteString("font_scale=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FontScale))
+	builder.WriteString(", ")
+	builder.WriteString("high_contrast=")
+	builder.WriteString(fmt.Sprintf("%v", _m.HighContrast))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/settings/settings.go
+++ b/backend/ent/settings/settings.go
@@ -37,6 +37,10 @@ const (
 	FieldUsageLoggingEnabled = "usage_logging_enabled"
 	// FieldInstallationID holds the string denoting the installation_id field in the database.
 	FieldInstallationID = "installation_id"
+	// FieldFontScale holds the string denoting the font_scale field in the database.
+	FieldFontScale = "font_scale"
+	// FieldHighContrast holds the string denoting the high_contrast field in the database.
+	FieldHighContrast = "high_contrast"
 	// Table holds the table name of the settings in the database.
 	Table = "settings"
 )
@@ -55,6 +59,8 @@ var Columns = []string{
 	FieldFeedbackLastPromptedAt,
 	FieldUsageLoggingEnabled,
 	FieldInstallationID,
+	FieldFontScale,
+	FieldHighContrast,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -86,6 +92,12 @@ var (
 	DefaultFullDiskAccessWarningDismissed bool
 	// DefaultInstallationID holds the default value on creation for the "installation_id" field.
 	DefaultInstallationID func() uuid.UUID
+	// DefaultFontScale holds the default value on creation for the "font_scale" field.
+	DefaultFontScale int
+	// FontScaleValidator is a validator for the "font_scale" field. It is called by the builders before save.
+	FontScaleValidator func(int) error
+	// DefaultHighContrast holds the default value on creation for the "high_contrast" field.
+	DefaultHighContrast bool
 )
 
 // Theme defines the type for the "theme" enum field.
@@ -176,4 +188,14 @@ func ByUsageLoggingEnabled(opts ...sql.OrderTermOption) OrderOption {
 // ByInstallationID orders the results by the installation_id field.
 func ByInstallationID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldInstallationID, opts...).ToFunc()
+}
+
+// ByFontScale orders the results by the font_scale field.
+func ByFontScale(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFontScale, opts...).ToFunc()
+}
+
+// ByHighContrast orders the results by the high_contrast field.
+func ByHighContrast(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldHighContrast, opts...).ToFunc()
 }

--- a/backend/ent/settings/where.go
+++ b/backend/ent/settings/where.go
@@ -105,6 +105,16 @@ func InstallationID(v uuid.UUID) predicate.Settings {
 	return predicate.Settings(sql.FieldEQ(FieldInstallationID, v))
 }
 
+// FontScale applies equality check predicate on the "font_scale" field. It's identical to FontScaleEQ.
+func FontScale(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldEQ(FieldFontScale, v))
+}
+
+// HighContrast applies equality check predicate on the "high_contrast" field. It's identical to HighContrastEQ.
+func HighContrast(v bool) predicate.Settings {
+	return predicate.Settings(sql.FieldEQ(FieldHighContrast, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Settings {
 	return predicate.Settings(sql.FieldEQ(FieldCreatedAt, v))
@@ -363,6 +373,56 @@ func InstallationIDLT(v uuid.UUID) predicate.Settings {
 // InstallationIDLTE applies the LTE predicate on the "installation_id" field.
 func InstallationIDLTE(v uuid.UUID) predicate.Settings {
 	return predicate.Settings(sql.FieldLTE(FieldInstallationID, v))
+}
+
+// FontScaleEQ applies the EQ predicate on the "font_scale" field.
+func FontScaleEQ(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldEQ(FieldFontScale, v))
+}
+
+// FontScaleNEQ applies the NEQ predicate on the "font_scale" field.
+func FontScaleNEQ(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldNEQ(FieldFontScale, v))
+}
+
+// FontScaleIn applies the In predicate on the "font_scale" field.
+func FontScaleIn(vs ...int) predicate.Settings {
+	return predicate.Settings(sql.FieldIn(FieldFontScale, vs...))
+}
+
+// FontScaleNotIn applies the NotIn predicate on the "font_scale" field.
+func FontScaleNotIn(vs ...int) predicate.Settings {
+	return predicate.Settings(sql.FieldNotIn(FieldFontScale, vs...))
+}
+
+// FontScaleGT applies the GT predicate on the "font_scale" field.
+func FontScaleGT(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldGT(FieldFontScale, v))
+}
+
+// FontScaleGTE applies the GTE predicate on the "font_scale" field.
+func FontScaleGTE(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldGTE(FieldFontScale, v))
+}
+
+// FontScaleLT applies the LT predicate on the "font_scale" field.
+func FontScaleLT(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldLT(FieldFontScale, v))
+}
+
+// FontScaleLTE applies the LTE predicate on the "font_scale" field.
+func FontScaleLTE(v int) predicate.Settings {
+	return predicate.Settings(sql.FieldLTE(FieldFontScale, v))
+}
+
+// HighContrastEQ applies the EQ predicate on the "high_contrast" field.
+func HighContrastEQ(v bool) predicate.Settings {
+	return predicate.Settings(sql.FieldEQ(FieldHighContrast, v))
+}
+
+// HighContrastNEQ applies the NEQ predicate on the "high_contrast" field.
+func HighContrastNEQ(v bool) predicate.Settings {
+	return predicate.Settings(sql.FieldNEQ(FieldHighContrast, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/backend/ent/settings_create.go
+++ b/backend/ent/settings_create.go
@@ -175,6 +175,34 @@ func (_c *SettingsCreate) SetNillableInstallationID(v *uuid.UUID) *SettingsCreat
 	return _c
 }
 
+// SetFontScale sets the "font_scale" field.
+func (_c *SettingsCreate) SetFontScale(v int) *SettingsCreate {
+	_c.mutation.SetFontScale(v)
+	return _c
+}
+
+// SetNillableFontScale sets the "font_scale" field if the given value is not nil.
+func (_c *SettingsCreate) SetNillableFontScale(v *int) *SettingsCreate {
+	if v != nil {
+		_c.SetFontScale(*v)
+	}
+	return _c
+}
+
+// SetHighContrast sets the "high_contrast" field.
+func (_c *SettingsCreate) SetHighContrast(v bool) *SettingsCreate {
+	_c.mutation.SetHighContrast(v)
+	return _c
+}
+
+// SetNillableHighContrast sets the "high_contrast" field if the given value is not nil.
+func (_c *SettingsCreate) SetNillableHighContrast(v *bool) *SettingsCreate {
+	if v != nil {
+		_c.SetHighContrast(*v)
+	}
+	return _c
+}
+
 // Mutation returns the SettingsMutation object of the builder.
 func (_c *SettingsCreate) Mutation() *SettingsMutation {
 	return _c.mutation
@@ -246,6 +274,14 @@ func (_c *SettingsCreate) defaults() {
 		v := settings.DefaultInstallationID()
 		_c.mutation.SetInstallationID(v)
 	}
+	if _, ok := _c.mutation.FontScale(); !ok {
+		v := settings.DefaultFontScale
+		_c.mutation.SetFontScale(v)
+	}
+	if _, ok := _c.mutation.HighContrast(); !ok {
+		v := settings.DefaultHighContrast
+		_c.mutation.SetHighContrast(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -281,6 +317,17 @@ func (_c *SettingsCreate) check() error {
 	}
 	if _, ok := _c.mutation.InstallationID(); !ok {
 		return &ValidationError{Name: "installation_id", err: errors.New(`ent: missing required field "Settings.installation_id"`)}
+	}
+	if _, ok := _c.mutation.FontScale(); !ok {
+		return &ValidationError{Name: "font_scale", err: errors.New(`ent: missing required field "Settings.font_scale"`)}
+	}
+	if v, ok := _c.mutation.FontScale(); ok {
+		if err := settings.FontScaleValidator(v); err != nil {
+			return &ValidationError{Name: "font_scale", err: fmt.Errorf(`ent: validator failed for field "Settings.font_scale": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.HighContrast(); !ok {
+		return &ValidationError{Name: "high_contrast", err: errors.New(`ent: missing required field "Settings.high_contrast"`)}
 	}
 	return nil
 }
@@ -351,6 +398,14 @@ func (_c *SettingsCreate) createSpec() (*Settings, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.InstallationID(); ok {
 		_spec.SetField(settings.FieldInstallationID, field.TypeUUID, value)
 		_node.InstallationID = value
+	}
+	if value, ok := _c.mutation.FontScale(); ok {
+		_spec.SetField(settings.FieldFontScale, field.TypeInt, value)
+		_node.FontScale = value
+	}
+	if value, ok := _c.mutation.HighContrast(); ok {
+		_spec.SetField(settings.FieldHighContrast, field.TypeBool, value)
+		_node.HighContrast = value
 	}
 	return _node, _spec
 }

--- a/backend/ent/settings_update.go
+++ b/backend/ent/settings_update.go
@@ -174,6 +174,41 @@ func (_u *SettingsUpdate) SetNillableInstallationID(v *uuid.UUID) *SettingsUpdat
 	return _u
 }
 
+// SetFontScale sets the "font_scale" field.
+func (_u *SettingsUpdate) SetFontScale(v int) *SettingsUpdate {
+	_u.mutation.ResetFontScale()
+	_u.mutation.SetFontScale(v)
+	return _u
+}
+
+// SetNillableFontScale sets the "font_scale" field if the given value is not nil.
+func (_u *SettingsUpdate) SetNillableFontScale(v *int) *SettingsUpdate {
+	if v != nil {
+		_u.SetFontScale(*v)
+	}
+	return _u
+}
+
+// AddFontScale adds value to the "font_scale" field.
+func (_u *SettingsUpdate) AddFontScale(v int) *SettingsUpdate {
+	_u.mutation.AddFontScale(v)
+	return _u
+}
+
+// SetHighContrast sets the "high_contrast" field.
+func (_u *SettingsUpdate) SetHighContrast(v bool) *SettingsUpdate {
+	_u.mutation.SetHighContrast(v)
+	return _u
+}
+
+// SetNillableHighContrast sets the "high_contrast" field if the given value is not nil.
+func (_u *SettingsUpdate) SetNillableHighContrast(v *bool) *SettingsUpdate {
+	if v != nil {
+		_u.SetHighContrast(*v)
+	}
+	return _u
+}
+
 // Mutation returns the SettingsMutation object of the builder.
 func (_u *SettingsUpdate) Mutation() *SettingsMutation {
 	return _u.mutation
@@ -220,6 +255,11 @@ func (_u *SettingsUpdate) check() error {
 	if v, ok := _u.mutation.Theme(); ok {
 		if err := settings.ThemeValidator(v); err != nil {
 			return &ValidationError{Name: "theme", err: fmt.Errorf(`ent: validator failed for field "Settings.theme": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FontScale(); ok {
+		if err := settings.FontScaleValidator(v); err != nil {
+			return &ValidationError{Name: "font_scale", err: fmt.Errorf(`ent: validator failed for field "Settings.font_scale": %w`, err)}
 		}
 	}
 	return nil
@@ -278,6 +318,15 @@ func (_u *SettingsUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.InstallationID(); ok {
 		_spec.SetField(settings.FieldInstallationID, field.TypeUUID, value)
+	}
+	if value, ok := _u.mutation.FontScale(); ok {
+		_spec.SetField(settings.FieldFontScale, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedFontScale(); ok {
+		_spec.AddField(settings.FieldFontScale, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.HighContrast(); ok {
+		_spec.SetField(settings.FieldHighContrast, field.TypeBool, value)
 	}
 	_spec.AddModifiers(_u.modifiers...)
 	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
@@ -445,6 +494,41 @@ func (_u *SettingsUpdateOne) SetNillableInstallationID(v *uuid.UUID) *SettingsUp
 	return _u
 }
 
+// SetFontScale sets the "font_scale" field.
+func (_u *SettingsUpdateOne) SetFontScale(v int) *SettingsUpdateOne {
+	_u.mutation.ResetFontScale()
+	_u.mutation.SetFontScale(v)
+	return _u
+}
+
+// SetNillableFontScale sets the "font_scale" field if the given value is not nil.
+func (_u *SettingsUpdateOne) SetNillableFontScale(v *int) *SettingsUpdateOne {
+	if v != nil {
+		_u.SetFontScale(*v)
+	}
+	return _u
+}
+
+// AddFontScale adds value to the "font_scale" field.
+func (_u *SettingsUpdateOne) AddFontScale(v int) *SettingsUpdateOne {
+	_u.mutation.AddFontScale(v)
+	return _u
+}
+
+// SetHighContrast sets the "high_contrast" field.
+func (_u *SettingsUpdateOne) SetHighContrast(v bool) *SettingsUpdateOne {
+	_u.mutation.SetHighContrast(v)
+	return _u
+}
+
+// SetNillableHighContrast sets the "high_contrast" field if the given value is not nil.
+func (_u *SettingsUpdateOne) SetNillableHighContrast(v *bool) *SettingsUpdateOne {
+	if v != nil {
+		_u.SetHighContrast(*v)
+	}
+	return _u
+}
+
 // Mutation returns the SettingsMutation object of the builder.
 func (_u *SettingsUpdateOne) Mutation() *SettingsMutation {
 	return _u.mutation
@@ -504,6 +588,11 @@ func (_u *SettingsUpdateOne) check() error {
 	if v, ok := _u.mutation.Theme(); ok {
 		if err := settings.ThemeValidator(v); err != nil {
 			return &ValidationError{Name: "theme", err: fmt.Errorf(`ent: validator failed for field "Settings.theme": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FontScale(); ok {
+		if err := settings.FontScaleValidator(v); err != nil {
+			return &ValidationError{Name: "font_scale", err: fmt.Errorf(`ent: validator failed for field "Settings.font_scale": %w`, err)}
 		}
 	}
 	return nil
@@ -579,6 +668,15 @@ func (_u *SettingsUpdateOne) sqlSave(ctx context.Context) (_node *Settings, err 
 	}
 	if value, ok := _u.mutation.InstallationID(); ok {
 		_spec.SetField(settings.FieldInstallationID, field.TypeUUID, value)
+	}
+	if value, ok := _u.mutation.FontScale(); ok {
+		_spec.SetField(settings.FieldFontScale, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedFontScale(); ok {
+		_spec.AddField(settings.FieldFontScale, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.HighContrast(); ok {
+		_spec.SetField(settings.FieldHighContrast, field.TypeBool, value)
 	}
 	_spec.AddModifiers(_u.modifiers...)
 	_node = &Settings{config: _u.config}

--- a/frontend/bindings/github.com/loomi-labs/arco/backend/ent/models.ts
+++ b/frontend/bindings/github.com/loomi-labs/arco/backend/ent/models.ts
@@ -1575,6 +1575,16 @@ export class Settings {
      */
     "installationId": uuid$0.UUID;
 
+    /**
+     * FontScale holds the value of the "font_scale" field.
+     */
+    "fontScale": number;
+
+    /**
+     * HighContrast holds the value of the "high_contrast" field.
+     */
+    "highContrast": boolean;
+
     /** Creates a new Settings instance. */
     constructor($$source: Partial<Settings> = {}) {
         if (!("createdAt" in $$source)) {
@@ -1606,6 +1616,12 @@ export class Settings {
         }
         if (!("installationId" in $$source)) {
             this["installationId"] = "";
+        }
+        if (!("fontScale" in $$source)) {
+            this["fontScale"] = 0;
+        }
+        if (!("highContrast" in $$source)) {
+            this["highContrast"] = false;
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,7 @@ import { useSubscriptionNotifications } from "./common/subscription";
 import { initializeTheme } from "./common/theme";
 import { initializeExpertMode, useExpertMode } from "./common/expertMode";
 import { initializeReducedMotion, setupReducedMotionListener } from "./common/reducedMotion";
+import { initializeAppearance, setupAppearanceListener } from "./common/appearance";
 import { setupPageViewTracking } from "./common/analytics";
 import { useNavigationShortcuts } from "./common/navigationShortcuts";
 import type { WailsEvent } from "@wailsio/runtime/types/events";
@@ -147,6 +148,9 @@ cleanupFunctions.push(setupSettingsListener());
 // Setup reduced motion settings listener
 cleanupFunctions.push(setupReducedMotionListener());
 
+// Setup appearance settings listener (font scale, high contrast)
+cleanupFunctions.push(setupAppearanceListener());
+
 // Setup navigation shortcuts (keyboard and mouse)
 const { setupNavigationShortcuts } = useNavigationShortcuts();
 cleanupFunctions.push(setupNavigationShortcuts());
@@ -160,6 +164,7 @@ watch(isInitialized, async (initialized) => {
     await initializeTheme();
     await initializeExpertMode();
     await initializeReducedMotion();
+    await initializeAppearance();
 
     // Start page view tracking after settings are available
     cleanupFunctions.push(setupPageViewTracking());

--- a/frontend/src/common/appearance.ts
+++ b/frontend/src/common/appearance.ts
@@ -1,0 +1,52 @@
+import * as userService from "../../bindings/github.com/loomi-labs/arco/backend/app/user/service";
+import * as types from "../../bindings/github.com/loomi-labs/arco/backend/app/types";
+import { logError } from "./logger";
+import { Events } from "@wailsio/runtime";
+
+/**
+ * Apply appearance settings (font scale and high contrast) to the document root
+ */
+export function applyAppearance(fontScale: number, highContrast: boolean): void {
+  const root = document.documentElement;
+
+  root.style.setProperty("--font-scale", String(fontScale / 100));
+
+  if (highContrast) {
+    root.classList.add("high-contrast");
+  } else {
+    root.classList.remove("high-contrast");
+  }
+}
+
+/**
+ * Initialize and apply the user's saved appearance preferences
+ * Should be called at app startup
+ */
+export async function initializeAppearance(): Promise<void> {
+  try {
+    const settings = await userService.GetSettings();
+    if (settings) {
+      // Wails binding constructor zero-value is fontScale=0, so use `|| 100`
+      applyAppearance(settings.fontScale || 100, settings.highContrast ?? false);
+    }
+  } catch (error: unknown) {
+    await logError("Failed to initialize appearance settings", error);
+  }
+}
+
+/**
+ * Setup listener for settings changes to update appearance in real-time
+ * Returns cleanup function
+ */
+export function setupAppearanceListener(): () => void {
+  return Events.On(types.Event.EventSettingsChanged, async () => {
+    try {
+      const settings = await userService.GetSettings();
+      if (settings) {
+        applyAppearance(settings.fontScale || 100, settings.highContrast ?? false);
+      }
+    } catch (error: unknown) {
+      await logError("Failed to update appearance settings", error);
+    }
+  });
+}

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -15,6 +15,7 @@ import { ComputerDesktopIcon } from "@heroicons/vue/24/solid";
 import { useAuth } from "../common/auth";
 import { useTheme } from "../common/theme";
 import { logError } from "../common/logger";
+import { applyAppearance } from "../common/appearance";
 import * as userService from "../../bindings/github.com/loomi-labs/arco/backend/app/user/service";
 import * as analyticsService from "../../bindings/github.com/loomi-labs/arco/backend/app/analytics/service";
 import type * as ent from "../../bindings/github.com/loomi-labs/arco/backend/ent";
@@ -44,6 +45,8 @@ const selectedTheme = ref<Theme>(Theme.ThemeSystem);
 const expertMode = ref(false);
 const disableTransitions = ref(false);
 const disableShadows = ref(false);
+const fontScale = ref(100);
+const highContrast = ref(false);
 const usageLoggingEnabled = ref(false);
 const showCollectedData = ref(false);
 
@@ -62,6 +65,8 @@ async function loadSettings() {
       expertMode.value = result.expertMode ?? false;
       disableTransitions.value = result.disableTransitions ?? false;
       disableShadows.value = result.disableShadows ?? false;
+      fontScale.value = result.fontScale || 100;
+      highContrast.value = result.highContrast ?? false;
       usageLoggingEnabled.value = result.usageLoggingEnabled === true;
 
       // Load theme from backend and apply it
@@ -99,6 +104,8 @@ async function saveSettings() {
     settings.value.expertMode = expertMode.value;
     settings.value.disableTransitions = disableTransitions.value;
     settings.value.disableShadows = disableShadows.value;
+    settings.value.fontScale = fontScale.value;
+    settings.value.highContrast = highContrast.value;
     await userService.SaveSettings(settings.value);
   } catch (error: unknown) {
     errorMessage.value = "Failed to save settings";
@@ -108,6 +115,21 @@ async function saveSettings() {
   }
 }
 
+
+function previewFontScale() {
+  // Apply the font scale live while dragging the slider (persisted on @change)
+  applyAppearance(fontScale.value, highContrast.value);
+}
+
+async function resetFontScale() {
+  fontScale.value = 100;
+  applyAppearance(fontScale.value, highContrast.value);
+  await saveSettings();
+}
+
+function applyHighContrast() {
+  applyAppearance(fontScale.value, highContrast.value);
+}
 
 async function saveAnalyticsPreference() {
   isSaving.value = true;
@@ -268,6 +290,56 @@ onMounted(async () => {
                   <ComputerDesktopIcon class='size-8' />
                   <span class='text-sm font-medium'>System</span>
                 </button>
+              </div>
+
+              <!-- Readability Options -->
+              <div class='divider'></div>
+              <p class='text-sm text-base-content/70'>Adjust text size and contrast for better readability</p>
+
+              <!-- Font Size -->
+              <div class='py-3 px-4 bg-base-100 rounded-lg'>
+                <div class='flex items-center justify-between'>
+                  <div class='flex items-center gap-2'>
+                    <p class='font-medium'>Font Size</p>
+                    <span class='text-sm text-base-content/70'>{{ fontScale }}%</span>
+                  </div>
+                  <button
+                    v-if='fontScale !== 100'
+                    class='btn btn-xs btn-ghost'
+                    :disabled='isSaving'
+                    @click='resetFontScale'
+                  >
+                    Reset
+                  </button>
+                </div>
+                <input
+                  type='range'
+                  min='80'
+                  max='150'
+                  step='5'
+                  v-model.number='fontScale'
+                  class='range range-secondary mt-3'
+                  :disabled='isSaving'
+                  @input='previewFontScale'
+                  @change='saveSettings'
+                />
+              </div>
+
+              <!-- High Contrast Text Toggle -->
+              <div class='flex items-center justify-between py-3 px-4 bg-base-100 rounded-lg'>
+                <div class='flex-1'>
+                  <p class='font-medium'>High Contrast Text</p>
+                  <p class='text-sm text-base-content/70 mt-1'>
+                    Increase text contrast for better readability
+                  </p>
+                </div>
+                <input
+                  type='checkbox'
+                  v-model='highContrast'
+                  @change='applyHighContrast(); saveSettings()'
+                  class='toggle toggle-secondary'
+                  :disabled='isSaving'
+                />
               </div>
 
               <!-- Reduced Motion Options -->

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -335,6 +335,7 @@ onMounted(async () => {
                 </div>
                 <input
                   type='checkbox'
+                  :key='`high-contrast-${fontScale}`'
                   v-model='highContrast'
                   @change='applyHighContrast(); saveSettings()'
                   class='toggle toggle-secondary'
@@ -354,8 +355,11 @@ onMounted(async () => {
                     Remove all animations and transitions
                   </p>
                 </div>
+                <!-- Keyed on fontScale: WebKitGTK renders toggles with stale layout after
+                     a live root font-size change; re-mounting them forces a fresh layout -->
                 <input
                   type='checkbox'
+                  :key='`disable-transitions-${fontScale}`'
                   v-model='disableTransitions'
                   @change='saveSettings'
                   class='toggle toggle-secondary'
@@ -373,6 +377,7 @@ onMounted(async () => {
                 </div>
                 <input
                   type='checkbox'
+                  :key='`disable-shadows-${fontScale}`'
                   v-model='disableShadows'
                   @change='saveSettings'
                   class='toggle toggle-secondary'
@@ -402,6 +407,7 @@ onMounted(async () => {
                 </div>
                 <input
                   type='checkbox'
+                  :key='`expert-mode-${fontScale}`'
                   v-model='expertMode'
                   @change='saveSettings'
                   class='toggle toggle-secondary'
@@ -444,6 +450,7 @@ onMounted(async () => {
                 </div>
                 <input
                   type='checkbox'
+                  :key='`usage-logging-${fontScale}`'
                   v-model='usageLoggingEnabled'
                   @change='saveAnalyticsPreference'
                   class='toggle toggle-secondary'

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -13,7 +13,7 @@
 
     /* Responsive font sizing - scales smoothly with viewport width */
     html {
-        font-size: clamp(13px, 1.1vw, 16px);
+        font-size: calc(clamp(13px, 1.1vw, 16px) * var(--font-scale, 1));
     }
 
     /* Reduced motion / accessibility utilities */
@@ -201,6 +201,15 @@
         --input-color: var(--color-primary);
         outline-color: var(--color-primary);
     }
+}
+
+/* High contrast text - overrides dimmed text opacities (see Settings > Appearance) */
+/* Kept unlayered so it beats Tailwind v4's layered utilities */
+.high-contrast :is(.text-base-content\/30, .text-base-content\/40, .text-base-content\/50, .text-base-content\/60) {
+    color: color-mix(in oklab, var(--color-base-content) 85%, transparent);
+}
+.high-contrast :is(.text-base-content\/70, .text-base-content\/80) {
+    color: var(--color-base-content);
 }
 
 /* Fix select text clipping - reduce line-height for Nunito font */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,11 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    // Bind IPv4 explicitly: the Wails3 dev asset proxy dials tcp4 only, but with
+    // the default host ("localhost") Node may bind ::1 only, causing a white screen
+    host: "127.0.0.1"
+  },
   build: {
     target: 'esnext'
   },


### PR DESCRIPTION
## Summary
- Add a **Font Size** slider (80–150%, live preview while dragging) and a **High Contrast Text** toggle to Settings → Appearance, addressing complaints about tiny, grey fonts (TECH-244)
- Font scale multiplies the rem base (`html { font-size }`), so the entire UI scales uniformly; high contrast overrides the dimmed `text-base-content/30–80` opacities via unlayered CSS
- New `font_scale` / `high_contrast` settings fields end-to-end: ent schema, migration (+ validator test), `SaveSettings`, regenerated bindings, and a `frontend/src/common/appearance.ts` composable following the existing reducedMotion pattern
- Fix dev-mode white screen: vite now binds `127.0.0.1` because the Wails3 dev asset proxy dials IPv4 only, while Node bound `localhost` to `::1` (all asset requests 502'd)
- Work around a WebKitGTK bug where toggles keep stale layout after a live root font-size change by re-mounting them (`:key` on `fontScale`)

Fixes TECH-244