### PR TITLE
feat: select borg binary based on host macOS version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tickets*
 
 # Git worktrees
 worktrees
+
+# jj workspaces (per-developer)
+/.workspaces/

--- a/backend/platform/borg.go
+++ b/backend/platform/borg.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -37,6 +38,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.5",
 		Version:       version.Must(version.NewVersion("1.4.5")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("15.0")), // built on macOS 15, requires macOS 15+ per upstream README
 		Arch:          "amd64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-x86_64-gh.tgz",
 		IsDirectory:   true,
@@ -47,6 +49,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.5",
 		Version:       version.Must(version.NewVersion("1.4.5")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("15.0")), // built on macOS 15, requires macOS 15+ per upstream README
 		Arch:          "arm64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-arm64-gh.tgz",
 		IsDirectory:   true,
@@ -86,6 +89,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.4",
 		Version:       version.Must(version.NewVersion("1.4.4")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("15.0")), // built on macOS 15, requires macOS 15+ per upstream README
 		Arch:          "amd64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.4/borg-macos-15-x86_64-gh.tgz",
 		IsDirectory:   true,
@@ -96,6 +100,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.4",
 		Version:       version.Must(version.NewVersion("1.4.4")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("15.0")), // built on macOS 15, requires macOS 15+ per upstream README
 		Arch:          "arm64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.4/borg-macos-15-arm64-gh.tgz",
 		IsDirectory:   true,
@@ -135,6 +140,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.3",
 		Version:       version.Must(version.NewVersion("1.4.3")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("13.0")), // built on macOS 13
 		Arch:          "amd64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.3/borg-macos-13-x86_64-gh.tgz",
 		IsDirectory:   true,
@@ -145,6 +151,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.3",
 		Version:       version.Must(version.NewVersion("1.4.3")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("14.0")), // built on macOS 14
 		Arch:          "arm64",
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.3/borg-macos-14-arm64-gh.tgz",
 		IsDirectory:   true,
@@ -183,6 +190,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.1",
 		Version:       version.Must(version.NewVersion("1.4.1")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("10.12")), // built on macOS 10.12
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-macos1012.tgz",
 		IsDirectory:   true,
 		SupportsMount: true, // Non-gh builds include llfuse
@@ -220,6 +228,7 @@ var Binaries = []BorgBinary{
 		Name:          "borg_1.4.0",
 		Version:       version.Must(version.NewVersion("1.4.0")),
 		Os:            Darwin,
+		MacOSVersion:  version.Must(version.NewVersion("10.12")), // built on macOS 10.12
 		Url:           "https://github.com/borgbackup/borg/releases/download/1.4.0/borg-macos1012",
 		SupportsMount: true, // Single binary includes llfuse
 	},
@@ -234,9 +243,8 @@ func GetLatestBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 		return BorgBinary{}, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
 
-	// 2. Find latest binary for current OS and architecture
-	var latestBinary BorgBinary
-	var latestVersion *version.Version
+	// 2. Ensure at least one binary exists for current OS and architecture
+	found := false
 
 	for _, binary := range binaries {
 		// Check OS compatibility
@@ -250,20 +258,27 @@ func GetLatestBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 			continue
 		}
 
-		// Track the latest version
-		if latestVersion == nil || binary.Version.GreaterThan(latestVersion) {
-			latestBinary = binary
-			latestVersion = binary.Version
-		}
+		found = true
+		break
 	}
 
-	if latestVersion == nil {
+	if !found {
 		return BorgBinary{}, fmt.Errorf("no binary found for operating system %s and architecture %s", runtime.GOOS, currentArch)
 	}
 
-	// 3. If on Darwin, return the architecture-matched binary
+	// 3. If on Darwin -> get macOS version and select appropriate binary
 	if IsMacOS() {
-		return latestBinary, nil
+		systemMacOS, err := getMacOSVersion()
+		if err != nil {
+			// If macOS version detection fails, fallback to lowest macOS requirement
+			return selectLowestMacOSBinary(binaries, currentArch, false), nil
+		}
+
+		// Select the highest Borg version whose macOS requirement the system satisfies.
+		// Like the glibc path below, this looks across all versions: 1.4.5/1.4.4 binaries
+		// require macOS 15, so older hosts fall back to the newest still-compatible
+		// version (e.g. 1.4.3) instead of getting a binary that won't run.
+		return selectBestMacOSBinary(binaries, currentArch, systemMacOS, false), nil
 	}
 
 	// 4. Otherwise we are on Linux -> get glibc version
@@ -322,6 +337,43 @@ func getGlibcVersion() (*version.Version, error) {
 	return v, nil
 }
 
+// getMacOSVersion detects the macOS product version on Darwin systems
+func getMacOSVersion() (*version.Version, error) {
+	if !IsMacOS() {
+		return nil, fmt.Errorf("only macOS supports sw_vers") // Not applicable for non-Darwin systems
+	}
+
+	cmd := exec.Command("sw_vers", "-productVersion")
+	// SYSTEM_VERSION_COMPAT=1 inherited from the environment makes sw_vers report "10.16"
+	// on Big Sur and later; force it off so we always see the real product version.
+	cmd.Env = append(os.Environ(), "SYSTEM_VERSION_COMPAT=0")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect macOS version: %w", err)
+	}
+
+	// Output is the bare product version, e.g. "15.5" or "13.6.1"
+	versionCandidate := strings.TrimSpace(string(output))
+	re := regexp.MustCompile(`^\d+(\.\d+)*$`)
+	if !re.MatchString(versionCandidate) {
+		return nil, fmt.Errorf("could not parse macOS version from sw_vers output: %s", versionCandidate)
+	}
+
+	v, err := version.NewVersion(versionCandidate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse macOS version %s: %w", versionCandidate, err)
+	}
+
+	// "10.16" never existed as a real product version; it is the compat shim's alias for
+	// Big Sur and later. Treat it as a detection failure so selection falls back to the
+	// lowest-requirement binary, which runs fine on any Big Sur+ machine.
+	if v.Equal(version.Must(version.NewVersion("10.16"))) {
+		return nil, fmt.Errorf("sw_vers reported compat-shimmed macOS version 10.16")
+	}
+
+	return v, nil
+}
+
 // selectLowestGlibcBinary returns the binary with the lowest GLIBC requirement for the given architecture
 func selectLowestGlibcBinary(binaries []BorgBinary, arch string) BorgBinary {
 	if len(binaries) == 0 {
@@ -360,9 +412,8 @@ func GetMountBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 		return BorgBinary{}, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
 
-	// Find latest binary for current OS and architecture that supports mount
-	var latestBinary BorgBinary
-	var latestVersion *version.Version
+	// Ensure at least one mount-capable binary exists for current OS and architecture
+	found := false
 
 	for _, binary := range binaries {
 		// Check OS compatibility
@@ -380,20 +431,24 @@ func GetMountBorgBinary(binaries []BorgBinary) (BorgBinary, error) {
 			continue
 		}
 
-		// Track the latest version
-		if latestVersion == nil || binary.Version.GreaterThan(latestVersion) {
-			latestBinary = binary
-			latestVersion = binary.Version
-		}
+		found = true
+		break
 	}
 
-	if latestVersion == nil {
+	if !found {
 		return BorgBinary{}, fmt.Errorf("no mount-capable binary found for operating system %s and architecture %s", runtime.GOOS, currentArch)
 	}
 
-	// If on Darwin, return the architecture-matched binary
+	// If on Darwin -> get macOS version and select appropriate mount-capable binary
 	if IsMacOS() {
-		return latestBinary, nil
+		systemMacOS, err := getMacOSVersion()
+		if err != nil {
+			// If macOS version detection fails, fallback to lowest macOS requirement with mount support
+			return selectLowestMacOSBinary(binaries, currentArch, true), nil
+		}
+
+		// Select the highest mount-capable Borg version whose macOS requirement the system satisfies.
+		return selectBestMacOSBinary(binaries, currentArch, systemMacOS, true), nil
 	}
 
 	// Otherwise we are on Linux -> get glibc version and select appropriate binary
@@ -493,4 +548,108 @@ func selectBestGlibcBinary(binaries []BorgBinary, arch string, systemGlibc *vers
 	}
 
 	return best
+}
+
+// selectBestMacOSBinary picks the best Darwin binary for the given architecture and macOS
+// version. It returns the highest Borg version whose macOS requirement is satisfied by the
+// system (MacOSVersion <= systemMacOS, nil meaning compatible with any macOS), breaking ties
+// toward the higher macOS requirement. When mountOnly is set, only mount-capable binaries are
+// considered.
+//
+// Like selectBestGlibcBinary, this searches across all versions so that an older macOS still
+// gets the newest compatible version (e.g. 1.4.5/1.4.4 require macOS 15, so a macOS 14 arm64
+// host falls back to 1.4.3). If the system is older than every available build, it falls back
+// to the lowest-requirement binary.
+func selectBestMacOSBinary(binaries []BorgBinary, arch string, systemMacOS *version.Version, mountOnly bool) BorgBinary {
+	var best BorgBinary
+	found := false
+
+	for _, binary := range binaries {
+		if binary.Os != Darwin {
+			continue
+		}
+
+		// Check architecture compatibility (empty means any)
+		if binary.Arch != "" && binary.Arch != arch {
+			continue
+		}
+
+		if mountOnly && !binary.SupportsMount {
+			continue
+		}
+
+		// Skip builds that require a newer macOS than the system provides.
+		// A nil MacOSVersion means the binary is compatible with any macOS.
+		if binary.MacOSVersion != nil && binary.MacOSVersion.GreaterThan(systemMacOS) {
+			continue
+		}
+
+		if !found ||
+			binary.Version.GreaterThan(best.Version) ||
+			(binary.Version.Equal(best.Version) && binary.MacOSVersion != nil &&
+				(best.MacOSVersion == nil || binary.MacOSVersion.GreaterThan(best.MacOSVersion))) {
+			best = binary
+			found = true
+		}
+	}
+
+	if !found {
+		// System macOS is older than every available build; return the lowest-requirement option.
+		return selectLowestMacOSBinary(binaries, arch, mountOnly)
+	}
+
+	return best
+}
+
+// selectLowestMacOSBinary returns the Darwin binary with the lowest macOS requirement for the
+// given architecture (nil MacOSVersion counts as the lowest possible requirement). Ties on the
+// requirement are broken toward the higher Borg version. When mountOnly is set, only
+// mount-capable binaries are considered.
+func selectLowestMacOSBinary(binaries []BorgBinary, arch string, mountOnly bool) BorgBinary {
+	var lowest BorgBinary
+	found := false
+
+	for _, binary := range binaries {
+		if binary.Os != Darwin {
+			continue
+		}
+
+		// Check architecture compatibility (empty means any)
+		if binary.Arch != "" && binary.Arch != arch {
+			continue
+		}
+
+		if mountOnly && !binary.SupportsMount {
+			continue
+		}
+
+		if !found || macOSRequirementLess(binary, lowest) ||
+			(macOSRequirementEqual(binary, lowest) && binary.Version.GreaterThan(lowest.Version)) {
+			lowest = binary
+			found = true
+		}
+	}
+
+	return lowest
+}
+
+// macOSRequirementLess reports whether a's macOS requirement is strictly lower than b's,
+// treating nil as the lowest possible requirement.
+func macOSRequirementLess(a, b BorgBinary) bool {
+	if a.MacOSVersion == nil {
+		return b.MacOSVersion != nil
+	}
+	if b.MacOSVersion == nil {
+		return false
+	}
+	return a.MacOSVersion.LessThan(b.MacOSVersion)
+}
+
+// macOSRequirementEqual reports whether a and b have the same macOS requirement,
+// treating two nil requirements as equal.
+func macOSRequirementEqual(a, b BorgBinary) bool {
+	if a.MacOSVersion == nil || b.MacOSVersion == nil {
+		return a.MacOSVersion == b.MacOSVersion
+	}
+	return a.MacOSVersion.Equal(b.MacOSVersion)
 }

--- a/backend/platform/borg_test.go
+++ b/backend/platform/borg_test.go
@@ -95,3 +95,105 @@ func TestSelectBestGlibcBinary(t *testing.T) {
 		})
 	}
 }
+
+// TestSelectBestMacOSBinary verifies that the newest Borg version compatible with the
+// host macOS version is selected: 1.4.5/1.4.4 binaries are built on macOS 15 and require
+// macOS 15+, so older hosts must fall back to the newest still-compatible version.
+func TestSelectBestMacOSBinary(t *testing.T) {
+	tests := []struct {
+		name        string
+		arch        string
+		systemMacOS string
+		mountOnly   bool
+		wantName    string
+		wantURL     string
+	}{
+		{
+			name:        "macOS 15 amd64 -> 1.4.5",
+			arch:        "amd64",
+			systemMacOS: "15.5",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-x86_64-gh.tgz",
+		},
+		{
+			name:        "exactly macOS 15.0 arm64 -> 1.4.5",
+			arch:        "arm64",
+			systemMacOS: "15.0",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-arm64-gh.tgz",
+		},
+		{
+			// 1.4.5/1.4.4 require macOS 15, so a macOS 14 host must fall back to 1.4.3.
+			name:        "macOS 14 arm64 -> 1.4.3",
+			arch:        "arm64",
+			systemMacOS: "14.7",
+			wantName:    "borg_1.4.3",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.3/borg-macos-14-arm64-gh.tgz",
+		},
+		{
+			name:        "macOS 13 amd64 -> 1.4.3",
+			arch:        "amd64",
+			systemMacOS: "13.6",
+			wantName:    "borg_1.4.3",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.3/borg-macos-13-x86_64-gh.tgz",
+		},
+		{
+			// The 1.4.3 arm64 build requires macOS 14, so a macOS 13 arm64 host must skip
+			// past it down to the arch-less 1.4.1 build (empty Arch matches any arch).
+			name:        "macOS 13 arm64 -> 1.4.1 (1.4.3 arm64 needs macOS 14)",
+			arch:        "arm64",
+			systemMacOS: "13.6",
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-macos1012.tgz",
+		},
+		{
+			name:        "macOS 12 amd64 -> 1.4.1",
+			arch:        "amd64",
+			systemMacOS: "12.7",
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-macos1012.tgz",
+		},
+		{
+			// Only the non-gh 1.4.1/1.4.0 builds include llfuse; 1.4.1 is the newest.
+			name:        "mountOnly on macOS 15 -> 1.4.1",
+			arch:        "arm64",
+			systemMacOS: "15.5",
+			mountOnly:   true,
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-macos1012.tgz",
+		},
+		{
+			// Older than every build -> lowest-requirement fallback; 1.4.1 and 1.4.0 both
+			// require 10.12, so the tie must break toward the higher Borg version.
+			name:        "macOS 10.11 -> lowest requirement fallback",
+			arch:        "amd64",
+			systemMacOS: "10.11",
+			wantName:    "borg_1.4.1",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.1/borg-macos1012.tgz",
+		},
+		{
+			// macOS jumped from 15 to 26 (Tahoe); plain numeric comparison must still work.
+			name:        "macOS 26 arm64 -> 1.4.5",
+			arch:        "arm64",
+			systemMacOS: "26.0",
+			wantName:    "borg_1.4.5",
+			wantURL:     "https://github.com/borgbackup/borg/releases/download/1.4.5/borg-macos-15-arm64-gh.tgz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectBestMacOSBinary(Binaries, tt.arch, mustVersion(t, tt.systemMacOS), tt.mountOnly)
+			if got.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Url != tt.wantURL {
+				t.Errorf("Url = %q, want %q", got.Url, tt.wantURL)
+			}
+			// A binary with an explicit Arch must never be selected for a different arch.
+			if got.Arch != "" && got.Arch != tt.arch {
+				t.Errorf("selected Arch = %q for %q host", got.Arch, tt.arch)
+			}
+		})
+	}
+}

--- a/backend/platform/types.go
+++ b/backend/platform/types.go
@@ -15,12 +15,13 @@ func (o OS) String() string {
 	return string(o)
 }
 
-// BorgBinary represents a Borg backup binary for a specific OS and GLIBC version
+// BorgBinary represents a Borg backup binary for a specific OS and platform requirement (GLIBC / macOS version)
 type BorgBinary struct {
 	Name          string
 	Version       *version.Version
 	Os            OS
-	GlibcVersion  *version.Version // Only applicable for Linux, nil for non-Linux
+	GlibcVersion  *version.Version // Minimum GLIBC version required. Only applicable for Linux, nil for non-Linux
+	MacOSVersion  *version.Version // Minimum macOS version required. Only applicable for Darwin, nil means compatible with any macOS
 	Arch          string           // CPU architecture (amd64, arm64), empty means any
 	Url           string
 	IsDirectory   bool // True for .tgz directory distributions (faster on macOS)


### PR DESCRIPTION
## Summary
- Borg 1.4.4/1.4.5 macOS binaries are built on macOS 15 and require macOS 15+ (bundled Homebrew dylibs carry that deployment target), so hosts on Ventura/Sonoma were handed a binary that cannot run
- Add a `MacOSVersion` requirement to each Darwin `BorgBinary` entry and detect the host version via `sw_vers -productVersion` (with `SYSTEM_VERSION_COMPAT=0` pinned to avoid the "10.16" compat shim)
- New `selectBestMacOSBinary`/`selectLowestMacOSBinary` mirror the existing glibc-based selection on Linux: pick the newest still-compatible release (e.g. macOS 14 → 1.4.3), fall back to the lowest-requirement build when detection fails
- Also ignore `/.workspaces/` (jj workspaces)

## Test plan
- `TestSelectBestMacOSBinary`: 9 table-driven cases incl. per-arch asymmetric requirements (1.4.3 needs macOS 13 on Intel / 14 on arm64), arch-less 1.4.1 fallback, mount-only selection, and the macOS 15→26 version jump